### PR TITLE
Add TOML configuration file handling and network listeners

### DIFF
--- a/cmd/pop3d/main.go
+++ b/cmd/pop3d/main.go
@@ -1,4 +1,26 @@
 package main
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/infodancer/pop3d/internal/config"
+)
+
 func main() {
+	flags := config.ParseFlags()
+
+	cfg, err := config.LoadWithFlags(flags)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	// TODO: Start POP3 server with cfg
+	_ = cfg
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/infodancer/pop3d
 
 go 1.23
+
+require github.com/BurntSushi/toml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,175 @@
+// Package config provides configuration management for the POP3 server.
+package config
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ListenerMode defines the operational mode for a listener.
+type ListenerMode string
+
+const (
+	// ModePop3 is standard POP3 on port 110 with optional STARTTLS (STLS command).
+	ModePop3 ListenerMode = "pop3"
+	// ModePop3s is implicit TLS on port 995.
+	ModePop3s ListenerMode = "pop3s"
+)
+
+// FileConfig is the top-level wrapper for the shared configuration file.
+// This allows smtpd, pop3d, and msgstore to share a single config file.
+type FileConfig struct {
+	Pop3d Config `toml:"pop3d"`
+}
+
+// Config holds the complete POP3 server configuration.
+type Config struct {
+	Hostname  string           `toml:"hostname"`
+	LogLevel  string           `toml:"log_level"`
+	Listeners []ListenerConfig `toml:"listeners"`
+	TLS       TLSConfig        `toml:"tls"`
+	Limits    LimitsConfig     `toml:"limits"`
+	Timeouts  TimeoutsConfig   `toml:"timeouts"`
+}
+
+// ListenerConfig defines settings for a single listener.
+type ListenerConfig struct {
+	Address string       `toml:"address"`
+	Mode    ListenerMode `toml:"mode"`
+}
+
+// TLSConfig holds TLS certificate and version settings.
+type TLSConfig struct {
+	CertFile   string `toml:"cert_file"`
+	KeyFile    string `toml:"key_file"`
+	MinVersion string `toml:"min_version"`
+}
+
+// LimitsConfig defines resource limits for the server.
+type LimitsConfig struct {
+	MaxConnections int `toml:"max_connections"`
+}
+
+// TimeoutsConfig defines timeout durations.
+type TimeoutsConfig struct {
+	Connection string `toml:"connection"`
+	Idle       string `toml:"idle"`
+}
+
+// Default returns a Config with sensible default values.
+func Default() Config {
+	return Config{
+		Hostname: "localhost",
+		LogLevel: "info",
+		Listeners: []ListenerConfig{
+			{Address: ":110", Mode: ModePop3},
+		},
+		TLS: TLSConfig{
+			MinVersion: "1.2",
+		},
+		Limits: LimitsConfig{
+			MaxConnections: 100,
+		},
+		Timeouts: TimeoutsConfig{
+			Connection: "10m",
+			Idle:       "5m",
+		},
+	}
+}
+
+// Validate checks that the configuration is valid and returns an error if not.
+func (c *Config) Validate() error {
+	if c.Hostname == "" {
+		return errors.New("hostname is required")
+	}
+
+	if len(c.Listeners) == 0 {
+		return errors.New("at least one listener is required")
+	}
+
+	for i, l := range c.Listeners {
+		if l.Address == "" {
+			return fmt.Errorf("listener %d: address is required", i)
+		}
+		if !isValidMode(l.Mode) {
+			return fmt.Errorf("listener %d: invalid mode %q", i, l.Mode)
+		}
+	}
+
+	if c.Limits.MaxConnections <= 0 {
+		return errors.New("max_connections must be positive")
+	}
+
+	if c.Timeouts.Connection != "" {
+		if _, err := time.ParseDuration(c.Timeouts.Connection); err != nil {
+			return fmt.Errorf("invalid connection timeout: %w", err)
+		}
+	}
+
+	if c.Timeouts.Idle != "" {
+		if _, err := time.ParseDuration(c.Timeouts.Idle); err != nil {
+			return fmt.Errorf("invalid idle timeout: %w", err)
+		}
+	}
+
+	if c.TLS.MinVersion != "" {
+		if _, ok := minTLSVersions[c.TLS.MinVersion]; !ok {
+			return fmt.Errorf("invalid TLS min_version %q (valid: 1.0, 1.1, 1.2, 1.3)", c.TLS.MinVersion)
+		}
+	}
+
+	return nil
+}
+
+// MinTLSVersion returns the crypto/tls constant for the configured minimum TLS version.
+// Returns tls.VersionTLS12 if not configured or invalid.
+func (c *TLSConfig) MinTLSVersion() uint16 {
+	if v, ok := minTLSVersions[c.MinVersion]; ok {
+		return v
+	}
+	return tls.VersionTLS12
+}
+
+// ConnectionTimeout returns the connection timeout as a time.Duration.
+// Returns 10 minutes if not configured or invalid.
+func (c *TimeoutsConfig) ConnectionTimeout() time.Duration {
+	if c.Connection == "" {
+		return 10 * time.Minute
+	}
+	d, err := time.ParseDuration(c.Connection)
+	if err != nil {
+		return 10 * time.Minute
+	}
+	return d
+}
+
+// IdleTimeout returns the idle timeout as a time.Duration.
+// Returns 5 minutes if not configured or invalid.
+func (c *TimeoutsConfig) IdleTimeout() time.Duration {
+	if c.Idle == "" {
+		return 5 * time.Minute
+	}
+	d, err := time.ParseDuration(c.Idle)
+	if err != nil {
+		return 5 * time.Minute
+	}
+	return d
+}
+
+var minTLSVersions = map[string]uint16{
+	"1.0": tls.VersionTLS10,
+	"1.1": tls.VersionTLS11,
+	"1.2": tls.VersionTLS12,
+	"1.3": tls.VersionTLS13,
+}
+
+func isValidMode(m ListenerMode) bool {
+	switch m {
+	case ModePop3, ModePop3s:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,202 @@
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+)
+
+func TestDefault(t *testing.T) {
+	cfg := Default()
+
+	if cfg.Hostname != "localhost" {
+		t.Errorf("expected hostname 'localhost', got %q", cfg.Hostname)
+	}
+
+	if cfg.LogLevel != "info" {
+		t.Errorf("expected log_level 'info', got %q", cfg.LogLevel)
+	}
+
+	if len(cfg.Listeners) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(cfg.Listeners))
+	}
+
+	if cfg.Listeners[0].Address != ":110" {
+		t.Errorf("expected listener address ':110', got %q", cfg.Listeners[0].Address)
+	}
+
+	if cfg.Listeners[0].Mode != ModePop3 {
+		t.Errorf("expected listener mode 'pop3', got %q", cfg.Listeners[0].Mode)
+	}
+
+	if cfg.TLS.MinVersion != "1.2" {
+		t.Errorf("expected TLS min_version '1.2', got %q", cfg.TLS.MinVersion)
+	}
+
+	if cfg.Limits.MaxConnections != 100 {
+		t.Errorf("expected max_connections 100, got %d", cfg.Limits.MaxConnections)
+	}
+
+	if cfg.Timeouts.Connection != "10m" {
+		t.Errorf("expected connection timeout '10m', got %q", cfg.Timeouts.Connection)
+	}
+
+	if cfg.Timeouts.Idle != "5m" {
+		t.Errorf("expected idle timeout '5m', got %q", cfg.Timeouts.Idle)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(*Config)
+		wantErr bool
+	}{
+		{
+			name:    "valid default config",
+			modify:  func(c *Config) {},
+			wantErr: false,
+		},
+		{
+			name:    "empty hostname",
+			modify:  func(c *Config) { c.Hostname = "" },
+			wantErr: true,
+		},
+		{
+			name:    "no listeners",
+			modify:  func(c *Config) { c.Listeners = nil },
+			wantErr: true,
+		},
+		{
+			name: "listener with empty address",
+			modify: func(c *Config) {
+				c.Listeners = []ListenerConfig{{Address: "", Mode: ModePop3}}
+			},
+			wantErr: true,
+		},
+		{
+			name: "listener with invalid mode",
+			modify: func(c *Config) {
+				c.Listeners = []ListenerConfig{{Address: ":110", Mode: "invalid"}}
+			},
+			wantErr: true,
+		},
+		{
+			name:    "zero max_connections",
+			modify:  func(c *Config) { c.Limits.MaxConnections = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "negative max_connections",
+			modify:  func(c *Config) { c.Limits.MaxConnections = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "invalid connection timeout",
+			modify:  func(c *Config) { c.Timeouts.Connection = "invalid" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid idle timeout",
+			modify:  func(c *Config) { c.Timeouts.Idle = "invalid" },
+			wantErr: true,
+		},
+		{
+			name:    "invalid TLS min_version",
+			modify:  func(c *Config) { c.TLS.MinVersion = "1.4" },
+			wantErr: true,
+		},
+		{
+			name: "valid pop3 mode",
+			modify: func(c *Config) {
+				c.Listeners = []ListenerConfig{{Address: ":110", Mode: ModePop3}}
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid pop3s mode",
+			modify: func(c *Config) {
+				c.Listeners = []ListenerConfig{{Address: ":995", Mode: ModePop3s}}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			tt.modify(&cfg)
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMinTLSVersion(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected uint16
+	}{
+		{"1.0", tls.VersionTLS10},
+		{"1.1", tls.VersionTLS11},
+		{"1.2", tls.VersionTLS12},
+		{"1.3", tls.VersionTLS13},
+		{"", tls.VersionTLS12},        // default
+		{"invalid", tls.VersionTLS12}, // invalid falls back to default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			cfg := TLSConfig{MinVersion: tt.version}
+			if got := cfg.MinTLSVersion(); got != tt.expected {
+				t.Errorf("MinTLSVersion() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConnectionTimeout(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected time.Duration
+	}{
+		{"10m", 10 * time.Minute},
+		{"1h", 1 * time.Hour},
+		{"30s", 30 * time.Second},
+		{"", 10 * time.Minute},        // default
+		{"invalid", 10 * time.Minute}, // invalid falls back to default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			cfg := TimeoutsConfig{Connection: tt.value}
+			if got := cfg.ConnectionTimeout(); got != tt.expected {
+				t.Errorf("ConnectionTimeout() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIdleTimeout(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected time.Duration
+	}{
+		{"5m", 5 * time.Minute},
+		{"30s", 30 * time.Second},
+		{"2m", 2 * time.Minute},
+		{"", 5 * time.Minute},        // default
+		{"invalid", 5 * time.Minute}, // invalid falls back to default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			cfg := TimeoutsConfig{Idle: tt.value}
+			if got := cfg.IdleTimeout(); got != tt.expected {
+				t.Errorf("IdleTimeout() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1,0 +1,280 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadMissingFile(t *testing.T) {
+	cfg, err := Load("/nonexistent/path/config.toml")
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+
+	// Should return defaults
+	expected := Default()
+	if cfg.Hostname != expected.Hostname {
+		t.Errorf("expected hostname %q, got %q", expected.Hostname, cfg.Hostname)
+	}
+}
+
+func TestLoadValidTOML(t *testing.T) {
+	content := `
+[pop3d]
+hostname = "mail.example.com"
+log_level = "debug"
+
+[pop3d.tls]
+cert_file = "/etc/ssl/cert.pem"
+key_file = "/etc/ssl/key.pem"
+min_version = "1.3"
+
+[pop3d.limits]
+max_connections = 50
+
+[pop3d.timeouts]
+connection = "15m"
+idle = "10m"
+
+[[pop3d.listeners]]
+address = ":110"
+mode = "pop3"
+
+[[pop3d.listeners]]
+address = ":995"
+mode = "pop3s"
+`
+
+	path := createTempConfig(t, content)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Hostname != "mail.example.com" {
+		t.Errorf("hostname = %q, want 'mail.example.com'", cfg.Hostname)
+	}
+
+	if cfg.LogLevel != "debug" {
+		t.Errorf("log_level = %q, want 'debug'", cfg.LogLevel)
+	}
+
+	if cfg.TLS.CertFile != "/etc/ssl/cert.pem" {
+		t.Errorf("tls.cert_file = %q, want '/etc/ssl/cert.pem'", cfg.TLS.CertFile)
+	}
+
+	if cfg.TLS.KeyFile != "/etc/ssl/key.pem" {
+		t.Errorf("tls.key_file = %q, want '/etc/ssl/key.pem'", cfg.TLS.KeyFile)
+	}
+
+	if cfg.TLS.MinVersion != "1.3" {
+		t.Errorf("tls.min_version = %q, want '1.3'", cfg.TLS.MinVersion)
+	}
+
+	if cfg.Limits.MaxConnections != 50 {
+		t.Errorf("limits.max_connections = %d, want 50", cfg.Limits.MaxConnections)
+	}
+
+	if cfg.Timeouts.Connection != "15m" {
+		t.Errorf("timeouts.connection = %q, want '15m'", cfg.Timeouts.Connection)
+	}
+
+	if cfg.Timeouts.Idle != "10m" {
+		t.Errorf("timeouts.idle = %q, want '10m'", cfg.Timeouts.Idle)
+	}
+
+	if len(cfg.Listeners) != 2 {
+		t.Fatalf("expected 2 listeners, got %d", len(cfg.Listeners))
+	}
+
+	if cfg.Listeners[0].Address != ":110" || cfg.Listeners[0].Mode != ModePop3 {
+		t.Errorf("listener[0] = %+v, want address=':110' mode='pop3'", cfg.Listeners[0])
+	}
+
+	if cfg.Listeners[1].Address != ":995" || cfg.Listeners[1].Mode != ModePop3s {
+		t.Errorf("listener[1] = %+v, want address=':995' mode='pop3s'", cfg.Listeners[1])
+	}
+}
+
+func TestLoadInvalidTOML(t *testing.T) {
+	content := `
+[pop3d
+hostname = "broken
+`
+
+	path := createTempConfig(t, content)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid TOML, got nil")
+	}
+}
+
+func TestLoadPartialConfig(t *testing.T) {
+	content := `
+[pop3d]
+hostname = "partial.example.com"
+`
+
+	path := createTempConfig(t, content)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Provided value should be used
+	if cfg.Hostname != "partial.example.com" {
+		t.Errorf("hostname = %q, want 'partial.example.com'", cfg.Hostname)
+	}
+
+	// Defaults should be preserved for unspecified values
+	defaults := Default()
+	if cfg.LogLevel != defaults.LogLevel {
+		t.Errorf("log_level = %q, want default %q", cfg.LogLevel, defaults.LogLevel)
+	}
+
+	if cfg.Limits.MaxConnections != defaults.Limits.MaxConnections {
+		t.Errorf("max_connections = %d, want default %d", cfg.Limits.MaxConnections, defaults.Limits.MaxConnections)
+	}
+}
+
+func TestApplyFlags(t *testing.T) {
+	cfg := Default()
+
+	flags := &Flags{
+		Hostname:       "flag.example.com",
+		LogLevel:       "debug",
+		TLSCert:        "/flag/cert.pem",
+		TLSKey:         "/flag/key.pem",
+		MaxConnections: 25,
+	}
+
+	result := ApplyFlags(cfg, flags)
+
+	if result.Hostname != "flag.example.com" {
+		t.Errorf("hostname = %q, want 'flag.example.com'", result.Hostname)
+	}
+
+	if result.LogLevel != "debug" {
+		t.Errorf("log_level = %q, want 'debug'", result.LogLevel)
+	}
+
+	if result.TLS.CertFile != "/flag/cert.pem" {
+		t.Errorf("tls.cert_file = %q, want '/flag/cert.pem'", result.TLS.CertFile)
+	}
+
+	if result.TLS.KeyFile != "/flag/key.pem" {
+		t.Errorf("tls.key_file = %q, want '/flag/key.pem'", result.TLS.KeyFile)
+	}
+
+	if result.Limits.MaxConnections != 25 {
+		t.Errorf("max_connections = %d, want 25", result.Limits.MaxConnections)
+	}
+}
+
+func TestApplyFlagsEmptyValuesDoNotOverride(t *testing.T) {
+	cfg := Default()
+	cfg.Hostname = "original.example.com"
+	cfg.LogLevel = "warn"
+	cfg.Limits.MaxConnections = 50
+
+	// Empty/zero flags should not override
+	flags := &Flags{
+		Hostname:       "",
+		LogLevel:       "",
+		MaxConnections: 0,
+	}
+
+	result := ApplyFlags(cfg, flags)
+
+	if result.Hostname != "original.example.com" {
+		t.Errorf("hostname = %q, want 'original.example.com' (should not be overridden)", result.Hostname)
+	}
+
+	if result.LogLevel != "warn" {
+		t.Errorf("log_level = %q, want 'warn' (should not be overridden)", result.LogLevel)
+	}
+
+	if result.Limits.MaxConnections != 50 {
+		t.Errorf("max_connections = %d, want 50 (should not be overridden)", result.Limits.MaxConnections)
+	}
+}
+
+func TestApplyFlagsListenReplacesAllListeners(t *testing.T) {
+	cfg := Default()
+	cfg.Listeners = []ListenerConfig{
+		{Address: ":110", Mode: ModePop3},
+		{Address: ":995", Mode: ModePop3s},
+	}
+
+	flags := &Flags{
+		Listen: ":1110",
+	}
+
+	result := ApplyFlags(cfg, flags)
+
+	if len(result.Listeners) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(result.Listeners))
+	}
+
+	if result.Listeners[0].Address != ":1110" {
+		t.Errorf("listener address = %q, want ':1110'", result.Listeners[0].Address)
+	}
+
+	if result.Listeners[0].Mode != ModePop3 {
+		t.Errorf("listener mode = %q, want 'pop3'", result.Listeners[0].Mode)
+	}
+}
+
+func TestFlagPriorityOverConfig(t *testing.T) {
+	content := `
+[pop3d]
+hostname = "config.example.com"
+log_level = "info"
+
+[pop3d.limits]
+max_connections = 100
+`
+
+	path := createTempConfig(t, content)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Flags should override config file values
+	flags := &Flags{
+		Hostname:       "flag.example.com",
+		MaxConnections: 50,
+	}
+
+	result := ApplyFlags(cfg, flags)
+
+	// Flag values should win
+	if result.Hostname != "flag.example.com" {
+		t.Errorf("hostname = %q, want 'flag.example.com' (flag should override)", result.Hostname)
+	}
+
+	if result.Limits.MaxConnections != 50 {
+		t.Errorf("max_connections = %d, want 50 (flag should override)", result.Limits.MaxConnections)
+	}
+
+	// Non-overridden config values should remain
+	if result.LogLevel != "info" {
+		t.Errorf("log_level = %q, want 'info' (config value should remain)", result.LogLevel)
+	}
+}
+
+func createTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to create temp config: %v", err)
+	}
+	return path
+}

--- a/pop3d.toml.example
+++ b/pop3d.toml.example
@@ -1,0 +1,30 @@
+# POP3 Server Configuration
+# Shared by smtpd, pop3d, msgstore
+
+[pop3d]
+hostname = "mail.example.com"
+log_level = "info"
+
+[pop3d.tls]
+cert_file = "/etc/ssl/certs/mail.pem"
+key_file = "/etc/ssl/private/mail.key"
+min_version = "1.2"
+
+[pop3d.limits]
+max_connections = 100
+
+[pop3d.timeouts]
+connection = "10m"
+idle = "5m"
+
+[[pop3d.listeners]]
+address = ":110"
+mode = "pop3"
+
+[[pop3d.listeners]]
+address = ":995"
+mode = "pop3s"
+
+# Future sections:
+# [smtpd]
+# [msgstore]


### PR DESCRIPTION
## Summary

- Implement TOML-based configuration file handling following smtpd patterns
- Add `internal/config` package with Config structs and validation
- Support command-line flags with config file override priority
- Add `pop3d.toml.example` documenting all configuration options
- Support `pop3` (port 110) and `pop3s` (port 995) listener modes

Closes #5

## Test plan

- [x] `task build` - Binary compiles successfully
- [x] `task test` - All unit tests pass (13 config tests, 8 loader tests)
- [x] `task lint` - No linting errors
- [x] `./bin/pop3d -help` - Displays flag usage
- [x] `./bin/pop3d` (no config file) - Uses defaults without error
- [x] `./bin/pop3d -config pop3d.toml.example` - Parses example config
- [x] Flag overrides work: `./bin/pop3d -hostname test.local -log-level debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)