### PR TITLE
Implement POP3 authentication with TLS-aware security controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ bin/
 # Editor/IDE
 # .idea/
 # .vscode/
+/pop3d

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,15 @@
 module github.com/infodancer/pop3d
 
-go 1.23
+go 1.24.0
 
-require github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+toolchain go1.24.4
+
+require (
+	github.com/infodancer/msgstore v0.0.0-20260119172740-b28c3738bb5f
+	github.com/pelletier/go-toml/v2 v2.2.4
+)
+
+require (
+	golang.org/x/crypto v0.47.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/infodancer/msgstore v0.0.0-20260119172740-b28c3738bb5f h1:ktcBKUBSafF1HwuWSCALwEt+b/4X20UF9iaHRN0EUVc=
+github.com/infodancer/msgstore v0.0.0-20260119172740-b28c3738bb5f/go.mod h1:gj2jONRoKtUjJr3DkvQkBiR54cl3B0llvKheNQ06Xfk=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,131 @@
+// Package logging provides centralized logging for the POP3 server.
+package logging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+// contextKey is used for storing loggers in context.
+type contextKey struct{}
+
+var loggerKey = contextKey{}
+
+// connectionCounter is used to generate unique connection IDs.
+var connectionCounter atomic.Uint64
+
+// NewLogger creates a new slog.Logger with the specified level.
+func NewLogger(level string) *slog.Logger {
+	var lvl slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "info":
+		lvl = slog.LevelInfo
+	case "warn", "warning":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: lvl,
+	}
+	handler := slog.NewTextHandler(os.Stderr, opts)
+	return slog.New(handler)
+}
+
+// WithConnection returns a new logger with connection-specific attributes.
+// It generates a unique connection ID for log correlation.
+func WithConnection(logger *slog.Logger, remoteAddr string) *slog.Logger {
+	connID := connectionCounter.Add(1)
+	return logger.With(
+		slog.Uint64("conn_id", connID),
+		slog.String("remote_addr", remoteAddr),
+	)
+}
+
+// WithListener returns a new logger with listener-specific attributes.
+func WithListener(logger *slog.Logger, address string, mode string) *slog.Logger {
+	return logger.With(
+		slog.String("listener", address),
+		slog.String("mode", mode),
+	)
+}
+
+// FromContext retrieves the logger from the context.
+// Returns the default logger if none is found.
+func FromContext(ctx context.Context) *slog.Logger {
+	if logger, ok := ctx.Value(loggerKey).(*slog.Logger); ok {
+		return logger
+	}
+	return slog.Default()
+}
+
+// NewContext returns a new context with the logger attached.
+func NewContext(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// TransactionWriter wraps an io.Writer to log all data written.
+// Used for debugging full POP3 transactions.
+type TransactionWriter struct {
+	w      io.Writer
+	logger *slog.Logger
+	prefix string
+}
+
+// NewTransactionWriter creates a writer that logs all data.
+func NewTransactionWriter(w io.Writer, logger *slog.Logger, prefix string) *TransactionWriter {
+	return &TransactionWriter{
+		w:      w,
+		logger: logger,
+		prefix: prefix,
+	}
+}
+
+// Write writes data and logs it.
+func (tw *TransactionWriter) Write(p []byte) (n int, err error) {
+	n, err = tw.w.Write(p)
+	if n > 0 {
+		tw.logger.Debug("transaction",
+			slog.String("direction", tw.prefix),
+			slog.String("data", string(p[:n])),
+		)
+	}
+	return n, err
+}
+
+// TransactionReader wraps an io.Reader to log all data read.
+type TransactionReader struct {
+	r      io.Reader
+	logger *slog.Logger
+	prefix string
+}
+
+// NewTransactionReader creates a reader that logs all data.
+func NewTransactionReader(r io.Reader, logger *slog.Logger, prefix string) *TransactionReader {
+	return &TransactionReader{
+		r:      r,
+		logger: logger,
+		prefix: prefix,
+	}
+}
+
+// Read reads data and logs it.
+func (tr *TransactionReader) Read(p []byte) (n int, err error) {
+	n, err = tr.r.Read(p)
+	if n > 0 {
+		tr.logger.Debug("transaction",
+			slog.String("direction", tr.prefix),
+			slog.String("data", string(p[:n])),
+		)
+	}
+	return n, err
+}

--- a/internal/pop3/auth_commands.go
+++ b/internal/pop3/auth_commands.go
@@ -1,0 +1,195 @@
+package pop3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/infodancer/msgstore"
+)
+
+// AuthProvider is the interface for authentication operations.
+type AuthProvider interface {
+	Authenticate(ctx context.Context, username, password string) (*msgstore.AuthSession, error)
+}
+
+// capaCommand implements the CAPA command (RFC 2449).
+type capaCommand struct{}
+
+func (c *capaCommand) Name() string {
+	return "CAPA"
+}
+
+func (c *capaCommand) Execute(ctx context.Context, sess *Session, conn ConnectionLogger, args []string) (Response, error) {
+	// CAPA takes no arguments
+	if len(args) > 0 {
+		return Response{OK: false, Message: "CAPA command takes no arguments"}, nil
+	}
+
+	caps := sess.Capabilities()
+
+	return Response{
+		OK:      true,
+		Message: "Capability list follows",
+		Lines:   caps,
+	}, nil
+}
+
+// stlsCommand implements the STLS command (RFC 2595).
+type stlsCommand struct{}
+
+func (s *stlsCommand) Name() string {
+	return "STLS"
+}
+
+func (s *stlsCommand) Execute(ctx context.Context, sess *Session, conn ConnectionLogger, args []string) (Response, error) {
+	// STLS takes no arguments
+	if len(args) > 0 {
+		return Response{OK: false, Message: "STLS command takes no arguments"}, nil
+	}
+
+	// STLS is only valid in AUTHORIZATION state
+	if sess.State() != StateAuthorization {
+		return Response{OK: false, Message: "Command not valid in this state"}, nil
+	}
+
+	// Check if STLS is available
+	if !sess.CanSTLS() {
+		if sess.IsTLSActive() {
+			return Response{OK: false, Message: "Already using TLS"}, nil
+		}
+		return Response{OK: false, Message: "TLS not available"}, nil
+	}
+
+	// Return success - the handler will perform the TLS upgrade
+	return Response{OK: true, Message: "Begin TLS negotiation"}, nil
+}
+
+// userCommand implements the USER command (RFC 1939).
+type userCommand struct{}
+
+func (u *userCommand) Name() string {
+	return "USER"
+}
+
+func (u *userCommand) Execute(ctx context.Context, sess *Session, conn ConnectionLogger, args []string) (Response, error) {
+	// USER is only valid in AUTHORIZATION state
+	if sess.State() != StateAuthorization {
+		return Response{OK: false, Message: "Command not valid in this state"}, nil
+	}
+
+	// Require TLS for USER command
+	if !sess.IsTLSActive() {
+		return Response{OK: false, Message: "TLS required for authentication"}, nil
+	}
+
+	// USER requires exactly one argument
+	if len(args) != 1 {
+		return Response{OK: false, Message: "USER command requires username argument"}, nil
+	}
+
+	username := args[0]
+	if username == "" {
+		return Response{OK: false, Message: "Username cannot be empty"}, nil
+	}
+
+	// Store the username in the session
+	sess.SetUsername(username)
+
+	return Response{OK: true, Message: fmt.Sprintf("User %s accepted", username)}, nil
+}
+
+// passCommand implements the PASS command (RFC 1939).
+type passCommand struct {
+	authProvider AuthProvider
+}
+
+func (p *passCommand) Name() string {
+	return "PASS"
+}
+
+func (p *passCommand) Execute(ctx context.Context, sess *Session, conn ConnectionLogger, args []string) (Response, error) {
+	// PASS is only valid in AUTHORIZATION state
+	if sess.State() != StateAuthorization {
+		return Response{OK: false, Message: "Command not valid in this state"}, nil
+	}
+
+	// Require TLS for PASS command
+	if !sess.IsTLSActive() {
+		return Response{OK: false, Message: "TLS required for authentication"}, nil
+	}
+
+	// USER must have been called first
+	username := sess.Username()
+	if username == "" {
+		return Response{OK: false, Message: "No username specified"}, nil
+	}
+
+	// PASS requires exactly one argument
+	if len(args) != 1 {
+		return Response{OK: false, Message: "PASS command requires password argument"}, nil
+	}
+
+	password := args[0]
+
+	// Authenticate using the auth provider
+	authSession, err := p.authProvider.Authenticate(ctx, username, password)
+	if err != nil {
+		// Return generic error to prevent user enumeration
+		conn.Logger().Info("authentication failed",
+			"username", username,
+			"error", err.Error(),
+		)
+		return Response{OK: false, Message: "Authentication failed"}, nil
+	}
+
+	// Authentication successful - transition to TRANSACTION state
+	sess.SetAuthenticated(authSession)
+
+	conn.Logger().Info("authentication successful",
+		"username", username,
+		"mailbox", authSession.User.Mailbox,
+	)
+
+	return Response{OK: true, Message: fmt.Sprintf("Logged in as %s", username)}, nil
+}
+
+// quitCommand implements the QUIT command (RFC 1939).
+type quitCommand struct{}
+
+func (q *quitCommand) Name() string {
+	return "QUIT"
+}
+
+func (q *quitCommand) Execute(ctx context.Context, sess *Session, conn ConnectionLogger, args []string) (Response, error) {
+	// QUIT takes no arguments
+	if len(args) > 0 {
+		return Response{OK: false, Message: "QUIT command takes no arguments"}, nil
+	}
+
+	var message string
+
+	switch sess.State() {
+	case StateAuthorization:
+		// Just say goodbye
+		message = "Goodbye"
+
+	case StateTransaction:
+		// Enter UPDATE state to commit changes (future: commit deletions)
+		sess.EnterUpdate()
+		message = "Logging out"
+
+	default:
+		message = "Goodbye"
+	}
+
+	return Response{OK: true, Message: message}, nil
+}
+
+// RegisterAuthCommands registers all authentication-related commands.
+func RegisterAuthCommands(authProvider AuthProvider) {
+	RegisterCommand(&capaCommand{})
+	RegisterCommand(&stlsCommand{})
+	RegisterCommand(&userCommand{})
+	RegisterCommand(&passCommand{authProvider: authProvider})
+	RegisterCommand(&quitCommand{})
+}

--- a/internal/pop3/auth_commands_test.go
+++ b/internal/pop3/auth_commands_test.go
@@ -1,0 +1,497 @@
+package pop3
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/infodancer/msgstore"
+	"github.com/infodancer/pop3d/internal/config"
+)
+
+// mockAuthProvider is a test double for AuthProvider.
+type mockAuthProvider struct {
+	authenticateFn func(ctx context.Context, username, password string) (*msgstore.AuthSession, error)
+}
+
+func (m *mockAuthProvider) Authenticate(ctx context.Context, username, password string) (*msgstore.AuthSession, error) {
+	if m.authenticateFn != nil {
+		return m.authenticateFn(ctx, username, password)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockAuthProvider) Close() error {
+	return nil
+}
+
+// mockConnection is a minimal mock for testing commands that need a logger.
+type mockConnection struct {
+	logger *slog.Logger
+}
+
+func (m *mockConnection) Logger() *slog.Logger {
+	if m.logger == nil {
+		// Return a no-op logger for tests
+		return slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1}))
+	}
+	return m.logger
+}
+
+func newMockConnection() *mockConnection {
+	return &mockConnection{}
+}
+
+// Test helper to create a session for testing
+func newTestSession(mode config.ListenerMode, isTLS bool) *Session {
+	return NewSession("test.example.com", mode, nil, isTLS)
+}
+
+func TestCapaCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		sess         *Session
+		args         []string
+		wantOK       bool
+		wantMessage  string
+		wantCapCount int
+	}{
+		{
+			name:         "CAPA with no TLS shows limited capabilities",
+			sess:         newTestSession(config.ModePop3, false),
+			args:         []string{},
+			wantOK:       true,
+			wantMessage:  "Capability list follows",
+			wantCapCount: 3, // TOP, UIDL, RESP-CODES (no USER, no STLS without TLS config)
+		},
+		{
+			name:         "CAPA with TLS shows USER",
+			sess:         newTestSession(config.ModePop3s, true),
+			args:         []string{},
+			wantOK:       true,
+			wantMessage:  "Capability list follows",
+			wantCapCount: 4, // USER, TOP, UIDL, RESP-CODES
+		},
+		{
+			name:    "CAPA with arguments fails",
+			sess:    newTestSession(config.ModePop3, false),
+			args:    []string{"invalid"},
+			wantOK:  false,
+			wantMessage: "CAPA command takes no arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &capaCommand{}
+			resp, err := cmd.Execute(context.Background(), tt.sess, nil, tt.args)
+
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			if resp.OK != tt.wantOK {
+				t.Errorf("Execute() OK = %v, want %v", resp.OK, tt.wantOK)
+			}
+
+			if resp.Message != tt.wantMessage {
+				t.Errorf("Execute() Message = %v, want %v", resp.Message, tt.wantMessage)
+			}
+
+			if tt.wantOK && len(resp.Lines) != tt.wantCapCount {
+				t.Errorf("Execute() capability count = %v, want %v (caps: %v)", len(resp.Lines), tt.wantCapCount, resp.Lines)
+			}
+		})
+	}
+}
+
+func TestStlsCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		sess        *Session
+		args        []string
+		wantOK      bool
+		wantMessage string
+	}{
+		{
+			name:        "STLS before TLS succeeds",
+			sess:        newTestSession(config.ModePop3, false),
+			args:        []string{},
+			wantOK:      false, // Fails because no TLS config
+			wantMessage: "TLS not available",
+		},
+		{
+			name:        "STLS with TLS already active fails",
+			sess:        newTestSession(config.ModePop3s, true),
+			args:        []string{},
+			wantOK:      false,
+			wantMessage: "Already using TLS",
+		},
+		{
+			name:        "STLS with arguments fails",
+			sess:        newTestSession(config.ModePop3, false),
+			args:        []string{"invalid"},
+			wantOK:      false,
+			wantMessage: "STLS command takes no arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &stlsCommand{}
+			resp, err := cmd.Execute(context.Background(), tt.sess, nil, tt.args)
+
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			if resp.OK != tt.wantOK {
+				t.Errorf("Execute() OK = %v, want %v", resp.OK, tt.wantOK)
+			}
+
+			if resp.Message != tt.wantMessage {
+				t.Errorf("Execute() Message = %v, want %v", resp.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestUserCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		sess        *Session
+		args        []string
+		wantOK      bool
+		wantMessage string
+	}{
+		{
+			name:        "USER without TLS fails",
+			sess:        newTestSession(config.ModePop3, false),
+			args:        []string{"testuser"},
+			wantOK:      false,
+			wantMessage: "TLS required for authentication",
+		},
+		{
+			name:        "USER with TLS succeeds",
+			sess:        newTestSession(config.ModePop3s, true),
+			args:        []string{"testuser"},
+			wantOK:      true,
+			wantMessage: "User testuser accepted",
+		},
+		{
+			name:        "USER without arguments fails",
+			sess:        newTestSession(config.ModePop3s, true),
+			args:        []string{},
+			wantOK:      false,
+			wantMessage: "USER command requires username argument",
+		},
+		{
+			name:        "USER with too many arguments fails",
+			sess:        newTestSession(config.ModePop3s, true),
+			args:        []string{"user1", "user2"},
+			wantOK:      false,
+			wantMessage: "USER command requires username argument",
+		},
+		{
+			name:        "USER with empty username fails",
+			sess:        newTestSession(config.ModePop3s, true),
+			args:        []string{""},
+			wantOK:      false,
+			wantMessage: "Username cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &userCommand{}
+			resp, err := cmd.Execute(context.Background(), tt.sess, nil, tt.args)
+
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			if resp.OK != tt.wantOK {
+				t.Errorf("Execute() OK = %v, want %v", resp.OK, tt.wantOK)
+			}
+
+			if resp.Message != tt.wantMessage {
+				t.Errorf("Execute() Message = %v, want %v", resp.Message, tt.wantMessage)
+			}
+
+			if tt.wantOK && tt.sess.Username() != tt.args[0] {
+				t.Errorf("Session username = %v, want %v", tt.sess.Username(), tt.args[0])
+			}
+		})
+	}
+}
+
+func TestPassCommand(t *testing.T) {
+	tests := []struct {
+		name          string
+		sess          *Session
+		setupSession  func(*Session)
+		args          []string
+		authFn        func(ctx context.Context, username, password string) (*msgstore.AuthSession, error)
+		wantOK        bool
+		wantMessage   string
+		wantState     State
+	}{
+		{
+			name:        "PASS without TLS fails",
+			sess:        newTestSession(config.ModePop3, false),
+			setupSession: func(s *Session) {
+				s.SetUsername("testuser")
+			},
+			args:        []string{"password"},
+			wantOK:      false,
+			wantMessage: "TLS required for authentication",
+			wantState:   StateAuthorization,
+		},
+		{
+			name:        "PASS without prior USER fails",
+			sess:        newTestSession(config.ModePop3s, true),
+			args:        []string{"password"},
+			wantOK:      false,
+			wantMessage: "No username specified",
+			wantState:   StateAuthorization,
+		},
+		{
+			name:        "PASS with successful auth",
+			sess:        newTestSession(config.ModePop3s, true),
+			setupSession: func(s *Session) {
+				s.SetUsername("testuser")
+			},
+			args: []string{"correctpassword"},
+			authFn: func(ctx context.Context, username, password string) (*msgstore.AuthSession, error) {
+				return &msgstore.AuthSession{
+					User: &msgstore.User{
+						Username: username,
+						Mailbox:  "/var/mail/" + username,
+					},
+				}, nil
+			},
+			wantOK:      true,
+			wantMessage: "Logged in as testuser",
+			wantState:   StateTransaction,
+		},
+		{
+			name:        "PASS with failed auth",
+			sess:        newTestSession(config.ModePop3s, true),
+			setupSession: func(s *Session) {
+				s.SetUsername("testuser")
+			},
+			args: []string{"wrongpassword"},
+			authFn: func(ctx context.Context, username, password string) (*msgstore.AuthSession, error) {
+				return nil, errors.New("invalid credentials")
+			},
+			wantOK:      false,
+			wantMessage: "Authentication failed",
+			wantState:   StateAuthorization,
+		},
+		{
+			name:        "PASS without arguments fails",
+			sess:        newTestSession(config.ModePop3s, true),
+			setupSession: func(s *Session) {
+				s.SetUsername("testuser")
+			},
+			args:        []string{},
+			wantOK:      false,
+			wantMessage: "PASS command requires password argument",
+			wantState:   StateAuthorization,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setupSession != nil {
+				tt.setupSession(tt.sess)
+			}
+
+			mockAuth := &mockAuthProvider{
+				authenticateFn: tt.authFn,
+			}
+
+			cmd := &passCommand{authProvider: mockAuth}
+
+			// Create a minimal mock connection for logging
+			conn := newMockConnection()
+			resp, err := cmd.Execute(context.Background(), tt.sess, conn, tt.args)
+
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			if resp.OK != tt.wantOK {
+				t.Errorf("Execute() OK = %v, want %v", resp.OK, tt.wantOK)
+			}
+
+			if resp.Message != tt.wantMessage {
+				t.Errorf("Execute() Message = %v, want %v", resp.Message, tt.wantMessage)
+			}
+
+			if tt.sess.State() != tt.wantState {
+				t.Errorf("Session state = %v, want %v", tt.sess.State(), tt.wantState)
+			}
+		})
+	}
+}
+
+func TestQuitCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		sess        *Session
+		setupSession func(*Session)
+		args        []string
+		wantOK      bool
+		wantMessage string
+		wantState   State
+	}{
+		{
+			name:        "QUIT in AUTHORIZATION",
+			sess:        newTestSession(config.ModePop3s, true),
+			args:        []string{},
+			wantOK:      true,
+			wantMessage: "Goodbye",
+			wantState:   StateAuthorization,
+		},
+		{
+			name:        "QUIT in TRANSACTION",
+			sess:        newTestSession(config.ModePop3s, true),
+			setupSession: func(s *Session) {
+				s.SetAuthenticated(&msgstore.AuthSession{
+					User: &msgstore.User{Username: "test"},
+				})
+			},
+			args:        []string{},
+			wantOK:      true,
+			wantMessage: "Logging out",
+			wantState:   StateUpdate,
+		},
+		{
+			name:        "QUIT with arguments fails",
+			sess:        newTestSession(config.ModePop3s, true),
+			args:        []string{"invalid"},
+			wantOK:      false,
+			wantMessage: "QUIT command takes no arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setupSession != nil {
+				tt.setupSession(tt.sess)
+			}
+
+			cmd := &quitCommand{}
+			resp, err := cmd.Execute(context.Background(), tt.sess, nil, tt.args)
+
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			if resp.OK != tt.wantOK {
+				t.Errorf("Execute() OK = %v, want %v", resp.OK, tt.wantOK)
+			}
+
+			if resp.Message != tt.wantMessage {
+				t.Errorf("Execute() Message = %v, want %v", resp.Message, tt.wantMessage)
+			}
+
+			if tt.wantOK && len(tt.args) == 0 {
+				if tt.sess.State() != tt.wantState {
+					t.Errorf("Session state = %v, want %v", tt.sess.State(), tt.wantState)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandRegistry(t *testing.T) {
+	// Clear the registry first
+	commandRegistry = make(map[string]Command)
+
+	// Register test commands
+	mockAuth := &mockAuthProvider{}
+	RegisterAuthCommands(mockAuth)
+
+	tests := []struct {
+		name      string
+		cmdName   string
+		wantFound bool
+	}{
+		{"CAPA exists", "CAPA", true},
+		{"capa exists (case insensitive)", "capa", true},
+		{"USER exists", "USER", true},
+		{"PASS exists", "PASS", true},
+		{"QUIT exists", "QUIT", true},
+		{"STLS exists", "STLS", true},
+		{"INVALID does not exist", "INVALID", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, found := GetCommand(tt.cmdName)
+
+			if found != tt.wantFound {
+				t.Errorf("GetCommand(%q) found = %v, want %v", tt.cmdName, found, tt.wantFound)
+			}
+
+			if tt.wantFound && cmd == nil {
+				t.Errorf("GetCommand(%q) returned nil command", tt.cmdName)
+			}
+		})
+	}
+}
+
+func TestResponseFormatting(t *testing.T) {
+	tests := []struct {
+		name     string
+		resp     Response
+		wantText string
+	}{
+		{
+			name: "Simple OK response",
+			resp: Response{
+				OK:      true,
+				Message: "Success",
+			},
+			wantText: "+OK Success\r\n",
+		},
+		{
+			name: "Simple ERR response",
+			resp: Response{
+				OK:      false,
+				Message: "Failed",
+			},
+			wantText: "-ERR Failed\r\n",
+		},
+		{
+			name: "Multi-line response",
+			resp: Response{
+				OK:      true,
+				Message: "Capabilities",
+				Lines:   []string{"USER", "TOP", "UIDL"},
+			},
+			wantText: "+OK Capabilities\r\nUSER\r\nTOP\r\nUIDL\r\n.\r\n",
+		},
+		{
+			name: "Response with dot-stuffing",
+			resp: Response{
+				OK:      true,
+				Message: "Data",
+				Lines:   []string{".hidden", "normal", "..double"},
+			},
+			wantText: "+OK Data\r\n..hidden\r\nnormal\r\n...double\r\n.\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.resp.String()
+			if got != tt.wantText {
+				t.Errorf("Response.String() = %q, want %q", got, tt.wantText)
+			}
+		})
+	}
+}

--- a/internal/pop3/command.go
+++ b/internal/pop3/command.go
@@ -1,0 +1,105 @@
+package pop3
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// ConnectionLogger is the interface for accessing logger from commands.
+type ConnectionLogger interface {
+	Logger() *slog.Logger
+}
+
+// Command represents a POP3 command that can be executed.
+type Command interface {
+	// Name returns the command name (e.g., "USER", "PASS", "QUIT").
+	Name() string
+
+	// Execute processes the command and returns a response.
+	// The response should not include the +OK or -ERR prefix.
+	// conn provides access to the connection logger.
+	Execute(ctx context.Context, sess *Session, conn ConnectionLogger, args []string) (Response, error)
+}
+
+// Response represents a POP3 response to a command.
+type Response struct {
+	// OK indicates success (+OK) or failure (-ERR).
+	OK bool
+
+	// Message is the response message (without +OK/-ERR prefix).
+	Message string
+
+	// Lines contains multi-line response data (for commands like CAPA).
+	// If present, will be sent after the +OK message, terminated by ".".
+	Lines []string
+}
+
+// String formats the response as a POP3 protocol string.
+func (r Response) String() string {
+	var sb strings.Builder
+
+	if r.OK {
+		sb.WriteString("+OK")
+	} else {
+		sb.WriteString("-ERR")
+	}
+
+	if r.Message != "" {
+		sb.WriteString(" ")
+		sb.WriteString(r.Message)
+	}
+
+	sb.WriteString("\r\n")
+
+	// Add multi-line data if present
+	if len(r.Lines) > 0 {
+		for _, line := range r.Lines {
+			// Byte-stuff lines that start with "."
+			if strings.HasPrefix(line, ".") {
+				sb.WriteString(".")
+			}
+			sb.WriteString(line)
+			sb.WriteString("\r\n")
+		}
+		sb.WriteString(".\r\n")
+	}
+
+	return sb.String()
+}
+
+// commandRegistry holds all registered commands.
+var commandRegistry = make(map[string]Command)
+
+// RegisterCommand registers a command in the registry.
+func RegisterCommand(cmd Command) {
+	commandRegistry[strings.ToUpper(cmd.Name())] = cmd
+}
+
+// GetCommand retrieves a command from the registry by name.
+func GetCommand(name string) (Command, bool) {
+	cmd, ok := commandRegistry[strings.ToUpper(name)]
+	return cmd, ok
+}
+
+// ParseCommand parses a POP3 command line into command name and arguments.
+// Returns the command name and arguments, or an error if the line is invalid.
+func ParseCommand(line string) (string, []string, error) {
+	// Trim whitespace
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", nil, fmt.Errorf("empty command")
+	}
+
+	// Split on whitespace
+	parts := strings.Fields(line)
+	if len(parts) == 0 {
+		return "", nil, fmt.Errorf("empty command")
+	}
+
+	cmdName := strings.ToUpper(parts[0])
+	args := parts[1:]
+
+	return cmdName, args, nil
+}

--- a/internal/pop3/command_test.go
+++ b/internal/pop3/command_test.go
@@ -1,0 +1,104 @@
+package pop3
+
+import (
+	"testing"
+)
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantCmd     string
+		wantArgs    []string
+		wantErr     bool
+	}{
+		{
+			name:     "Simple command without args",
+			line:     "QUIT",
+			wantCmd:  "QUIT",
+			wantArgs: []string{},
+			wantErr:  false,
+		},
+		{
+			name:     "Command with one arg",
+			line:     "USER alice",
+			wantCmd:  "USER",
+			wantArgs: []string{"alice"},
+			wantErr:  false,
+		},
+		{
+			name:     "Command with multiple args",
+			line:     "COMMAND arg1 arg2 arg3",
+			wantCmd:  "COMMAND",
+			wantArgs: []string{"arg1", "arg2", "arg3"},
+			wantErr:  false,
+		},
+		{
+			name:     "Command with extra whitespace",
+			line:     "  USER   alice  ",
+			wantCmd:  "USER",
+			wantArgs: []string{"alice"},
+			wantErr:  false,
+		},
+		{
+			name:     "Lowercase command",
+			line:     "user alice",
+			wantCmd:  "USER",
+			wantArgs: []string{"alice"},
+			wantErr:  false,
+		},
+		{
+			name:     "Mixed case command",
+			line:     "QuIt",
+			wantCmd:  "QUIT",
+			wantArgs: []string{},
+			wantErr:  false,
+		},
+		{
+			name:     "Empty line",
+			line:     "",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "Whitespace only",
+			line:     "   ",
+			wantCmd:  "",
+			wantArgs: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, args, err := ParseCommand(tt.line)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseCommand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if cmd != tt.wantCmd {
+				t.Errorf("ParseCommand() cmd = %v, want %v", cmd, tt.wantCmd)
+			}
+
+			if !stringSlicesEqual(args, tt.wantArgs) {
+				t.Errorf("ParseCommand() args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+// Helper function to compare string slices
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pop3/errors.go
+++ b/internal/pop3/errors.go
@@ -1,0 +1,27 @@
+package pop3
+
+import "errors"
+
+// Protocol errors for POP3.
+var (
+	// ErrInvalidState is returned when a command is not valid in the current state.
+	ErrInvalidState = errors.New("command not valid in current state")
+
+	// ErrTLSRequired is returned when authentication is attempted without TLS.
+	ErrTLSRequired = errors.New("TLS required for authentication")
+
+	// ErrTLSNotAvailable is returned when STLS is requested but TLS is not configured.
+	ErrTLSNotAvailable = errors.New("TLS not available")
+
+	// ErrAlreadyTLS is returned when STLS is requested on an already-encrypted connection.
+	ErrAlreadyTLS = errors.New("already using TLS")
+
+	// ErrNoUsername is returned when PASS is used before USER.
+	ErrNoUsername = errors.New("username not specified")
+
+	// ErrAuthFailed is returned when authentication fails.
+	ErrAuthFailed = errors.New("authentication failed")
+
+	// ErrInvalidCommand is returned when a command is not recognized.
+	ErrInvalidCommand = errors.New("invalid command")
+)

--- a/internal/pop3/handler.go
+++ b/internal/pop3/handler.go
@@ -1,0 +1,199 @@
+package pop3
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/infodancer/pop3d/internal/config"
+	"github.com/infodancer/pop3d/internal/logging"
+	"github.com/infodancer/pop3d/internal/server"
+)
+
+// Handler creates a POP3 protocol handler with the given configuration.
+func Handler(hostname string, authProvider AuthProvider, tlsConfig *tls.Config) server.ConnectionHandler {
+	// Register authentication commands with the auth provider
+	RegisterAuthCommands(authProvider)
+
+	return func(ctx context.Context, conn *server.Connection) {
+		handleConnection(ctx, conn, hostname, tlsConfig)
+	}
+}
+
+// handleConnection manages a single POP3 connection.
+func handleConnection(ctx context.Context, conn *server.Connection, hostname string, tlsConfig *tls.Config) {
+	logger := logging.FromContext(ctx)
+
+	// Determine listener mode based on connection state
+	// If already TLS, assume ModePop3s; otherwise ModePop3
+	listenerMode := config.ModePop3
+	if conn.IsTLS() {
+		listenerMode = config.ModePop3s
+	}
+
+	// Create session
+	sess := NewSession(hostname, listenerMode, tlsConfig, conn.IsTLS())
+	defer sess.Cleanup()
+
+	logger.Info("starting POP3 session",
+		"state", sess.State().String(),
+		"tls_state", sess.TLSState().String(),
+	)
+
+	// Send greeting
+	greeting := fmt.Sprintf("+OK %s POP3 server ready\r\n", hostname)
+	if _, err := conn.Writer().WriteString(greeting); err != nil {
+		logger.Error("failed to send greeting", "error", err.Error())
+		return
+	}
+	if err := conn.Flush(); err != nil {
+		logger.Error("failed to flush greeting", "error", err.Error())
+		return
+	}
+
+	// Command loop
+	for {
+		// Check if context is cancelled
+		select {
+		case <-ctx.Done():
+			logger.Info("context cancelled, closing connection")
+			return
+		default:
+		}
+
+		// Check if connection is closed
+		if conn.IsClosed() {
+			logger.Info("connection closed")
+			return
+		}
+
+		// Set command timeout
+		if err := conn.SetCommandTimeout(); err != nil {
+			logger.Error("failed to set command timeout", "error", err.Error())
+			return
+		}
+
+		// Read command line
+		line, err := conn.Reader().ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				logger.Info("client closed connection")
+				return
+			}
+			logger.Error("error reading command", "error", err.Error())
+			return
+		}
+
+		// Reset idle timeout after successful read
+		if err := conn.ResetIdleTimeout(); err != nil {
+			logger.Error("failed to reset idle timeout", "error", err.Error())
+			return
+		}
+
+		// Trim whitespace
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		logger.Debug("received command", "line", line)
+
+		// Parse command
+		cmdName, args, err := ParseCommand(line)
+		if err != nil {
+			sendError(conn, logger, "Invalid command")
+			continue
+		}
+
+		// Look up command
+		cmd, ok := GetCommand(cmdName)
+		if !ok {
+			sendError(conn, logger, "Unknown command")
+			continue
+		}
+
+		logger.Debug("executing command",
+			"command", cmdName,
+			"args_count", len(args),
+		)
+
+		// Execute command
+		resp, err := cmd.Execute(ctx, sess, conn, args)
+		if err != nil {
+			logger.Error("command execution error",
+				"command", cmdName,
+				"error", err.Error(),
+			)
+			sendError(conn, logger, "Internal server error")
+			continue
+		}
+
+		// Send response
+		if _, err := conn.Writer().WriteString(resp.String()); err != nil {
+			logger.Error("failed to send response", "error", err.Error())
+			return
+		}
+		if err := conn.Flush(); err != nil {
+			logger.Error("failed to flush response", "error", err.Error())
+			return
+		}
+
+		logger.Debug("sent response",
+			"ok", resp.OK,
+			"message", resp.Message,
+		)
+
+		// Handle special cases
+		switch cmdName {
+		case "STLS":
+			// If STLS succeeded, upgrade the connection to TLS
+			if resp.OK {
+				if err := upgradeToTLS(ctx, conn, sess); err != nil {
+					logger.Error("TLS upgrade failed", "error", err.Error())
+					return
+				}
+				logger.Info("TLS upgrade successful",
+					"tls_state", sess.TLSState().String(),
+				)
+			}
+
+		case "QUIT":
+			// QUIT always closes the connection
+			logger.Info("QUIT command received, closing connection")
+			return
+		}
+	}
+}
+
+// upgradeToTLS performs the TLS upgrade after STLS command.
+func upgradeToTLS(ctx context.Context, conn *server.Connection, sess *Session) error {
+	logger := logging.FromContext(ctx)
+
+	tlsConfig := sess.TLSConfig()
+	if tlsConfig == nil {
+		return fmt.Errorf("no TLS configuration available")
+	}
+
+	logger.Info("upgrading connection to TLS")
+
+	// Perform TLS upgrade on the connection
+	if err := conn.UpgradeToTLS(tlsConfig); err != nil {
+		return fmt.Errorf("TLS handshake failed: %w", err)
+	}
+
+	// Update session state
+	sess.SetTLSActive()
+
+	return nil
+}
+
+// sendError sends an error response to the client.
+func sendError(conn *server.Connection, logger interface{}, message string) {
+	resp := Response{OK: false, Message: message}
+	if _, err := conn.Writer().WriteString(resp.String()); err != nil {
+		return
+	}
+	_ = conn.Flush()
+}

--- a/internal/pop3/session.go
+++ b/internal/pop3/session.go
@@ -1,0 +1,188 @@
+package pop3
+
+import (
+	"crypto/tls"
+
+	"github.com/infodancer/msgstore"
+	"github.com/infodancer/pop3d/internal/config"
+)
+
+// State represents the current state in the POP3 state machine.
+type State int
+
+const (
+	// StateAuthorization is the initial state where authentication is required.
+	StateAuthorization State = iota
+
+	// StateTransaction is the state after successful authentication.
+	StateTransaction
+
+	// StateUpdate is the state after QUIT from Transaction (for committing changes).
+	StateUpdate
+)
+
+// String returns the string representation of the state.
+func (s State) String() string {
+	switch s {
+	case StateAuthorization:
+		return "AUTHORIZATION"
+	case StateTransaction:
+		return "TRANSACTION"
+	case StateUpdate:
+		return "UPDATE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// TLSState represents the current TLS encryption state of the connection.
+type TLSState int
+
+const (
+	// TLSStateNone indicates no TLS protection (ModePop3 before STARTTLS).
+	TLSStateNone TLSState = iota
+
+	// TLSStateActive indicates TLS is active (after STARTTLS or ModePop3s implicit).
+	TLSStateActive
+)
+
+// String returns the string representation of the TLS state.
+func (ts TLSState) String() string {
+	switch ts {
+	case TLSStateNone:
+		return "NONE"
+	case TLSStateActive:
+		return "ACTIVE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Session represents a POP3 session with state tracking.
+type Session struct {
+	// State machine
+	state    State
+	tlsState TLSState
+
+	// Configuration
+	hostname     string
+	listenerMode config.ListenerMode
+	tlsConfig    *tls.Config
+
+	// Authentication state
+	username    string
+	authSession *msgstore.AuthSession
+}
+
+// NewSession creates a new POP3 session.
+func NewSession(hostname string, mode config.ListenerMode, tlsConfig *tls.Config, isTLS bool) *Session {
+	// Determine initial TLS state based on listener mode and connection state
+	tlsState := TLSStateNone
+	if mode == config.ModePop3s || isTLS {
+		tlsState = TLSStateActive
+	}
+
+	return &Session{
+		state:        StateAuthorization,
+		tlsState:     tlsState,
+		hostname:     hostname,
+		listenerMode: mode,
+		tlsConfig:    tlsConfig,
+	}
+}
+
+// State returns the current POP3 state.
+func (s *Session) State() State {
+	return s.state
+}
+
+// TLSState returns the current TLS state.
+func (s *Session) TLSState() TLSState {
+	return s.tlsState
+}
+
+// SetTLSActive marks the connection as using TLS.
+// Should be called after successful STARTTLS upgrade.
+func (s *Session) SetTLSActive() {
+	s.tlsState = TLSStateActive
+}
+
+// IsTLSActive returns true if TLS is currently active.
+func (s *Session) IsTLSActive() bool {
+	return s.tlsState == TLSStateActive
+}
+
+// CanSTLS returns true if STLS command is available.
+// STLS is only available in StateAuthorization on ModePop3 listeners before TLS.
+func (s *Session) CanSTLS() bool {
+	return s.state == StateAuthorization &&
+		s.listenerMode == config.ModePop3 &&
+		s.tlsState == TLSStateNone &&
+		s.tlsConfig != nil
+}
+
+// TLSConfig returns the TLS configuration for STARTTLS.
+func (s *Session) TLSConfig() *tls.Config {
+	return s.tlsConfig
+}
+
+// SetUsername stores the username from the USER command.
+func (s *Session) SetUsername(username string) {
+	s.username = username
+}
+
+// Username returns the stored username.
+func (s *Session) Username() string {
+	return s.username
+}
+
+// SetAuthenticated transitions to StateTransaction after successful authentication.
+// Stores the AuthSession for later use.
+func (s *Session) SetAuthenticated(authSession *msgstore.AuthSession) {
+	s.state = StateTransaction
+	s.authSession = authSession
+}
+
+// IsAuthenticated returns true if in StateTransaction or StateUpdate.
+func (s *Session) IsAuthenticated() bool {
+	return s.state == StateTransaction || s.state == StateUpdate
+}
+
+// AuthSession returns the authentication session, or nil if not authenticated.
+func (s *Session) AuthSession() *msgstore.AuthSession {
+	return s.authSession
+}
+
+// EnterUpdate transitions to StateUpdate (called when QUIT is received in Transaction).
+func (s *Session) EnterUpdate() {
+	if s.state == StateTransaction {
+		s.state = StateUpdate
+	}
+}
+
+// Capabilities returns the list of capabilities for this session.
+// Capabilities change based on TLS state and listener mode.
+func (s *Session) Capabilities() []string {
+	caps := []string{"TOP", "UIDL", "RESP-CODES"}
+
+	// Only advertise USER if TLS is active
+	if s.tlsState == TLSStateActive {
+		caps = append([]string{"USER"}, caps...)
+	}
+
+	// Only advertise STLS if it's available
+	if s.CanSTLS() {
+		caps = append(caps, "STLS")
+	}
+
+	return caps
+}
+
+// Cleanup performs cleanup when the session ends.
+// Zeros sensitive key material if authenticated.
+func (s *Session) Cleanup() {
+	if s.authSession != nil {
+		s.authSession.Clear()
+		s.authSession = nil
+	}
+}

--- a/internal/pop3/session_test.go
+++ b/internal/pop3/session_test.go
@@ -1,0 +1,337 @@
+package pop3
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/infodancer/msgstore"
+	"github.com/infodancer/pop3d/internal/config"
+)
+
+func TestNewSession(t *testing.T) {
+	tests := []struct {
+		name         string
+		hostname     string
+		mode         config.ListenerMode
+		isTLS        bool
+		wantState    State
+		wantTLSState TLSState
+	}{
+		{
+			name:         "ModePop3 without TLS",
+			hostname:     "test.example.com",
+			mode:         config.ModePop3,
+			isTLS:        false,
+			wantState:    StateAuthorization,
+			wantTLSState: TLSStateNone,
+		},
+		{
+			name:         "ModePop3s with implicit TLS",
+			hostname:     "test.example.com",
+			mode:         config.ModePop3s,
+			isTLS:        true,
+			wantState:    StateAuthorization,
+			wantTLSState: TLSStateActive,
+		},
+		{
+			name:         "ModePop3 with explicit TLS",
+			hostname:     "test.example.com",
+			mode:         config.ModePop3,
+			isTLS:        true,
+			wantState:    StateAuthorization,
+			wantTLSState: TLSStateActive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess := NewSession(tt.hostname, tt.mode, nil, tt.isTLS)
+
+			if sess.State() != tt.wantState {
+				t.Errorf("NewSession() state = %v, want %v", sess.State(), tt.wantState)
+			}
+
+			if sess.TLSState() != tt.wantTLSState {
+				t.Errorf("NewSession() tlsState = %v, want %v", sess.TLSState(), tt.wantTLSState)
+			}
+		})
+	}
+}
+
+func TestSessionTLSManagement(t *testing.T) {
+	sess := NewSession("test.example.com", config.ModePop3, nil, false)
+
+	// Initial state should be no TLS
+	if sess.IsTLSActive() {
+		t.Error("Expected TLS to be inactive initially")
+	}
+
+	// Activate TLS
+	sess.SetTLSActive()
+
+	if !sess.IsTLSActive() {
+		t.Error("Expected TLS to be active after SetTLSActive()")
+	}
+
+	if sess.TLSState() != TLSStateActive {
+		t.Errorf("TLSState = %v, want %v", sess.TLSState(), TLSStateActive)
+	}
+}
+
+func TestCanSTLS(t *testing.T) {
+	tlsConfig := &tls.Config{}
+
+	tests := []struct {
+		name      string
+		mode      config.ListenerMode
+		isTLS     bool
+		tlsConfig *tls.Config
+		want      bool
+	}{
+		{
+			name:      "ModePop3 without TLS config",
+			mode:      config.ModePop3,
+			isTLS:     false,
+			tlsConfig: nil,
+			want:      false,
+		},
+		{
+			name:      "ModePop3 with TLS config before upgrade",
+			mode:      config.ModePop3,
+			isTLS:     false,
+			tlsConfig: tlsConfig,
+			want:      true,
+		},
+		{
+			name:      "ModePop3 after TLS upgrade",
+			mode:      config.ModePop3,
+			isTLS:     true,
+			tlsConfig: tlsConfig,
+			want:      false,
+		},
+		{
+			name:      "ModePop3s (implicit TLS)",
+			mode:      config.ModePop3s,
+			isTLS:     true,
+			tlsConfig: tlsConfig,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess := NewSession("test.example.com", tt.mode, tt.tlsConfig, tt.isTLS)
+
+			if got := sess.CanSTLS(); got != tt.want {
+				t.Errorf("CanSTLS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionAuthentication(t *testing.T) {
+	sess := NewSession("test.example.com", config.ModePop3s, nil, true)
+
+	// Initially not authenticated
+	if sess.IsAuthenticated() {
+		t.Error("Session should not be authenticated initially")
+	}
+
+	if sess.AuthSession() != nil {
+		t.Error("AuthSession() should return nil when not authenticated")
+	}
+
+	// Set username
+	sess.SetUsername("testuser")
+	if sess.Username() != "testuser" {
+		t.Errorf("Username() = %v, want testuser", sess.Username())
+	}
+
+	// Authenticate
+	authSession := &msgstore.AuthSession{
+		User: &msgstore.User{
+			Username: "testuser",
+			Mailbox:  "/var/mail/testuser",
+		},
+	}
+	sess.SetAuthenticated(authSession)
+
+	// Should now be authenticated
+	if !sess.IsAuthenticated() {
+		t.Error("Session should be authenticated after SetAuthenticated()")
+	}
+
+	if sess.State() != StateTransaction {
+		t.Errorf("State = %v, want %v", sess.State(), StateTransaction)
+	}
+
+	if sess.AuthSession() != authSession {
+		t.Error("AuthSession() should return the authenticated session")
+	}
+}
+
+func TestSessionStateTransitions(t *testing.T) {
+	sess := NewSession("test.example.com", config.ModePop3s, nil, true)
+
+	// Start in AUTHORIZATION
+	if sess.State() != StateAuthorization {
+		t.Errorf("Initial state = %v, want %v", sess.State(), StateAuthorization)
+	}
+
+	// Authenticate -> TRANSACTION
+	authSession := &msgstore.AuthSession{
+		User: &msgstore.User{Username: "test"},
+	}
+	sess.SetAuthenticated(authSession)
+
+	if sess.State() != StateTransaction {
+		t.Errorf("After SetAuthenticated state = %v, want %v", sess.State(), StateTransaction)
+	}
+
+	// QUIT -> UPDATE
+	sess.EnterUpdate()
+
+	if sess.State() != StateUpdate {
+		t.Errorf("After EnterUpdate state = %v, want %v", sess.State(), StateUpdate)
+	}
+
+	// Should still be authenticated in UPDATE state
+	if !sess.IsAuthenticated() {
+		t.Error("Session should still be authenticated in UPDATE state")
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	tests := []struct {
+		name          string
+		mode          config.ListenerMode
+		isTLS         bool
+		tlsConfig     *tls.Config
+		wantCapCount  int
+		wantHasUser   bool
+		wantHasSTLS   bool
+	}{
+		{
+			name:          "ModePop3 without TLS config",
+			mode:          config.ModePop3,
+			isTLS:         false,
+			tlsConfig:     nil,
+			wantCapCount:  3, // TOP, UIDL, RESP-CODES
+			wantHasUser:   false,
+			wantHasSTLS:   false,
+		},
+		{
+			name:          "ModePop3 with TLS config before upgrade",
+			mode:          config.ModePop3,
+			isTLS:         false,
+			tlsConfig:     &tls.Config{},
+			wantCapCount:  4, // TOP, UIDL, RESP-CODES, STLS
+			wantHasUser:   false,
+			wantHasSTLS:   true,
+		},
+		{
+			name:          "ModePop3s with implicit TLS",
+			mode:          config.ModePop3s,
+			isTLS:         true,
+			tlsConfig:     &tls.Config{},
+			wantCapCount:  4, // USER, TOP, UIDL, RESP-CODES
+			wantHasUser:   true,
+			wantHasSTLS:   false,
+		},
+		{
+			name:          "ModePop3 after STARTTLS",
+			mode:          config.ModePop3,
+			isTLS:         true,
+			tlsConfig:     &tls.Config{},
+			wantCapCount:  4, // USER, TOP, UIDL, RESP-CODES
+			wantHasUser:   true,
+			wantHasSTLS:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess := NewSession("test.example.com", tt.mode, tt.tlsConfig, tt.isTLS)
+			caps := sess.Capabilities()
+
+			if len(caps) != tt.wantCapCount {
+				t.Errorf("Capabilities() count = %v, want %v (caps: %v)", len(caps), tt.wantCapCount, caps)
+			}
+
+			hasUser := false
+			hasSTLS := false
+			for _, cap := range caps {
+				if cap == "USER" {
+					hasUser = true
+				}
+				if cap == "STLS" {
+					hasSTLS = true
+				}
+			}
+
+			if hasUser != tt.wantHasUser {
+				t.Errorf("Capabilities() hasUser = %v, want %v", hasUser, tt.wantHasUser)
+			}
+
+			if hasSTLS != tt.wantHasSTLS {
+				t.Errorf("Capabilities() hasSTLS = %v, want %v", hasSTLS, tt.wantHasSTLS)
+			}
+		})
+	}
+}
+
+func TestSessionCleanup(t *testing.T) {
+	sess := NewSession("test.example.com", config.ModePop3s, nil, true)
+
+	// Authenticate with a session
+	authSession := &msgstore.AuthSession{
+		User: &msgstore.User{Username: "test"},
+	}
+	sess.SetAuthenticated(authSession)
+
+	// Cleanup should zero the auth session
+	sess.Cleanup()
+
+	if sess.AuthSession() != nil {
+		t.Error("AuthSession should be nil after Cleanup()")
+	}
+}
+
+func TestStateString(t *testing.T) {
+	tests := []struct {
+		state State
+		want  string
+	}{
+		{StateAuthorization, "AUTHORIZATION"},
+		{StateTransaction, "TRANSACTION"},
+		{StateUpdate, "UPDATE"},
+		{State(999), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.state.String(); got != tt.want {
+				t.Errorf("State.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTLSStateString(t *testing.T) {
+	tests := []struct {
+		state TLSState
+		want  string
+	}{
+		{TLSStateNone, "NONE"},
+		{TLSStateActive, "ACTIVE"},
+		{TLSState(999), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.state.String(); got != tt.want {
+				t.Errorf("TLSState.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -1,0 +1,250 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/infodancer/pop3d/internal/logging"
+)
+
+// Connection wraps a net.Conn with timeout management and optional transaction logging.
+type Connection struct {
+	conn           net.Conn
+	reader         *bufio.Reader
+	writer         *bufio.Writer
+	logger         *slog.Logger
+	idleTimeout    time.Duration
+	commandTimeout time.Duration
+	logTx          bool
+
+	mu           sync.Mutex
+	lastActivity time.Time
+	closed       bool
+}
+
+// ConnectionConfig holds configuration for a new connection.
+type ConnectionConfig struct {
+	IdleTimeout    time.Duration
+	CommandTimeout time.Duration
+	LogTransaction bool
+	Logger         *slog.Logger
+}
+
+// NewConnection creates a new Connection wrapper.
+func NewConnection(conn net.Conn, cfg ConnectionConfig) *Connection {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Create connection-scoped logger with remote address
+	connLogger := logging.WithConnection(logger, conn.RemoteAddr().String())
+
+	c := &Connection{
+		conn:           conn,
+		logger:         connLogger,
+		idleTimeout:    cfg.IdleTimeout,
+		commandTimeout: cfg.CommandTimeout,
+		logTx:          cfg.LogTransaction,
+		lastActivity:   time.Now(),
+	}
+
+	// Set up reader/writer with optional transaction logging
+	var r io.Reader = conn
+	var w io.Writer = conn
+
+	if cfg.LogTransaction {
+		r = logging.NewTransactionReader(conn, connLogger, "recv")
+		w = logging.NewTransactionWriter(conn, connLogger, "send")
+	}
+
+	c.reader = bufio.NewReader(r)
+	c.writer = bufio.NewWriter(w)
+
+	return c
+}
+
+// Logger returns the connection-scoped logger.
+func (c *Connection) Logger() *slog.Logger {
+	return c.logger
+}
+
+// RemoteAddr returns the remote address of the connection.
+func (c *Connection) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+// LocalAddr returns the local address of the connection.
+func (c *Connection) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+// Reader returns the buffered reader for the connection.
+func (c *Connection) Reader() *bufio.Reader {
+	return c.reader
+}
+
+// Writer returns the buffered writer for the connection.
+func (c *Connection) Writer() *bufio.Writer {
+	return c.writer
+}
+
+// Flush flushes the write buffer.
+func (c *Connection) Flush() error {
+	return c.writer.Flush()
+}
+
+// SetDeadline sets the read and write deadlines.
+func (c *Connection) SetDeadline(t time.Time) error {
+	return c.conn.SetDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline.
+func (c *Connection) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline.
+func (c *Connection) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
+}
+
+// ResetIdleTimeout resets the idle timeout deadline.
+// Should be called after each successful read/write operation.
+func (c *Connection) ResetIdleTimeout() error {
+	c.mu.Lock()
+	c.lastActivity = time.Now()
+	c.mu.Unlock()
+
+	if c.idleTimeout > 0 {
+		return c.conn.SetDeadline(time.Now().Add(c.idleTimeout))
+	}
+	return nil
+}
+
+// SetCommandTimeout sets a deadline for the next command read.
+func (c *Connection) SetCommandTimeout() error {
+	if c.commandTimeout > 0 {
+		return c.conn.SetReadDeadline(time.Now().Add(c.commandTimeout))
+	}
+	return nil
+}
+
+// Close closes the connection.
+func (c *Connection) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+
+	c.logger.Debug("connection closed")
+	return c.conn.Close()
+}
+
+// IsClosed returns true if the connection has been closed.
+func (c *Connection) IsClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
+// Underlying returns the underlying net.Conn.
+// Use with caution; prefer the Connection methods.
+func (c *Connection) Underlying() net.Conn {
+	return c.conn
+}
+
+// IsTLS returns true if the connection is encrypted with TLS.
+func (c *Connection) IsTLS() bool {
+	_, ok := c.conn.(*tls.Conn)
+	return ok
+}
+
+// UpgradeToTLS upgrades the connection to TLS using the provided config.
+// Returns an error if the upgrade fails or if already using TLS.
+func (c *Connection) UpgradeToTLS(tlsConfig *tls.Config) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.IsTLS() {
+		return ErrAlreadyTLS
+	}
+
+	// Flush any pending writes before upgrade
+	if err := c.writer.Flush(); err != nil {
+		return err
+	}
+
+	// Perform TLS handshake
+	tlsConn := tls.Server(c.conn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		return err
+	}
+
+	// Replace the underlying connection
+	c.conn = tlsConn
+
+	// Recreate reader/writer with the new TLS connection
+	var r io.Reader = tlsConn
+	var w io.Writer = tlsConn
+
+	if c.logTx {
+		r = logging.NewTransactionReader(tlsConn, c.logger, "recv")
+		w = logging.NewTransactionWriter(tlsConn, c.logger, "send")
+	}
+
+	c.reader = bufio.NewReader(r)
+	c.writer = bufio.NewWriter(w)
+
+	c.logger.Info("TLS upgrade completed")
+
+	return nil
+}
+
+// IdleMonitor runs in a goroutine to monitor for idle connections.
+// It will close the connection if idle timeout is exceeded.
+// The monitor stops when the context is cancelled or the connection is closed.
+func (c *Connection) IdleMonitor(ctx context.Context) {
+	if c.idleTimeout <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(c.idleTimeout / 2)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.mu.Lock()
+			if c.closed {
+				c.mu.Unlock()
+				return
+			}
+			idle := time.Since(c.lastActivity)
+			c.mu.Unlock()
+
+			if idle >= c.idleTimeout {
+				c.logger.Info("closing idle connection",
+					slog.Duration("idle_time", idle),
+				)
+				if err := c.Close(); err != nil {
+					c.logger.Debug("error closing idle connection",
+						slog.String("error", err.Error()),
+					)
+				}
+				return
+			}
+		}
+	}
+}

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -1,0 +1,8 @@
+package server
+
+import "errors"
+
+var (
+	// ErrAlreadyTLS is returned when attempting to upgrade an already-TLS connection.
+	ErrAlreadyTLS = errors.New("connection already using TLS")
+)

--- a/internal/server/listener.go
+++ b/internal/server/listener.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/infodancer/pop3d/internal/config"
+	"github.com/infodancer/pop3d/internal/logging"
+)
+
+// ConnectionHandler is called for each new connection.
+// It receives the context and connection, and should handle the POP3 session.
+type ConnectionHandler func(ctx context.Context, conn *Connection)
+
+// Listener manages a single TCP listener for accepting POP3 connections.
+type Listener struct {
+	address   string
+	mode      config.ListenerMode
+	tlsConfig *tls.Config
+	connCfg   ConnectionConfig
+	handler   ConnectionHandler
+	logger    *slog.Logger
+
+	listener net.Listener
+	wg       sync.WaitGroup
+	mu       sync.Mutex
+	closed   bool
+}
+
+// ListenerConfig holds configuration for creating a new Listener.
+type ListenerConfig struct {
+	Address        string
+	Mode           config.ListenerMode
+	TLSConfig      *tls.Config
+	IdleTimeout    time.Duration
+	CommandTimeout time.Duration
+	LogTransaction bool
+	Logger         *slog.Logger
+	Handler        ConnectionHandler
+}
+
+// NewListener creates a new Listener with the given configuration.
+func NewListener(cfg ListenerConfig) *Listener {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &Listener{
+		address:   cfg.Address,
+		mode:      cfg.Mode,
+		tlsConfig: cfg.TLSConfig,
+		connCfg: ConnectionConfig{
+			IdleTimeout:    cfg.IdleTimeout,
+			CommandTimeout: cfg.CommandTimeout,
+			LogTransaction: cfg.LogTransaction,
+			Logger:         logger,
+		},
+		handler: cfg.Handler,
+		logger:  logging.WithListener(logger, cfg.Address, string(cfg.Mode)),
+	}
+}
+
+// Start begins listening for connections.
+// It blocks until the context is cancelled or an unrecoverable error occurs.
+func (l *Listener) Start(ctx context.Context) error {
+	var err error
+	var ln net.Listener
+
+	// For POP3S mode, wrap with TLS immediately
+	if l.mode == config.ModePop3s {
+		if l.tlsConfig == nil {
+			return errors.New("TLS configuration required for POP3S mode")
+		}
+		ln, err = tls.Listen("tcp", l.address, l.tlsConfig)
+	} else {
+		ln, err = net.Listen("tcp", l.address)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	l.mu.Lock()
+	l.listener = ln
+	l.mu.Unlock()
+
+	l.logger.Info("listener started",
+		slog.String("address", l.address),
+		slog.String("mode", string(l.mode)),
+	)
+
+	// Start accept loop in goroutine
+	go l.acceptLoop(ctx)
+
+	// Wait for context cancellation
+	<-ctx.Done()
+
+	l.logger.Info("listener shutting down")
+
+	// Close the listener to stop accepting new connections
+	if err := l.Close(); err != nil {
+		l.logger.Debug("error closing listener",
+			slog.String("error", err.Error()),
+		)
+	}
+
+	// Wait for all connections to complete
+	l.wg.Wait()
+
+	l.logger.Info("listener stopped")
+	return ctx.Err()
+}
+
+// acceptLoop accepts connections until the listener is closed.
+func (l *Listener) acceptLoop(ctx context.Context) {
+	for {
+		conn, err := l.listener.Accept()
+		if err != nil {
+			l.mu.Lock()
+			closed := l.closed
+			l.mu.Unlock()
+
+			if closed {
+				return
+			}
+
+			// Check if it's a temporary error
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				l.logger.Warn("temporary accept error",
+					slog.String("error", err.Error()),
+				)
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+
+			l.logger.Error("accept error",
+				slog.String("error", err.Error()),
+			)
+			return
+		}
+
+		// Handle connection in its own goroutine
+		l.wg.Add(1)
+		go l.handleConnection(ctx, conn)
+	}
+}
+
+// handleConnection wraps a connection and calls the handler.
+func (l *Listener) handleConnection(ctx context.Context, netConn net.Conn) {
+	defer l.wg.Done()
+
+	// Create connection wrapper
+	conn := NewConnection(netConn, l.connCfg)
+
+	conn.Logger().Info("connection accepted")
+
+	// Create connection-specific context
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Attach logger to context
+	connCtx = logging.NewContext(connCtx, conn.Logger())
+
+	// Set initial idle timeout
+	if err := conn.ResetIdleTimeout(); err != nil {
+		conn.Logger().Error("failed to set initial timeout",
+			slog.String("error", err.Error()),
+		)
+		_ = conn.Close()
+		return
+	}
+
+	// Start idle monitor
+	go conn.IdleMonitor(connCtx)
+
+	// Call the connection handler
+	if l.handler != nil {
+		l.handler(connCtx, conn)
+	}
+
+	_ = conn.Close()
+	conn.Logger().Info("connection closed")
+}
+
+// Close stops the listener from accepting new connections.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+
+	if l.listener != nil {
+		return l.listener.Close()
+	}
+	return nil
+}
+
+// Address returns the listener's address.
+func (l *Listener) Address() string {
+	return l.address
+}
+
+// Mode returns the listener's mode.
+func (l *Listener) Mode() config.ListenerMode {
+	return l.mode
+}
+
+// TLSConfig returns the TLS configuration, if any.
+// For non-POP3S modes, this can be used for STLS.
+func (l *Listener) TLSConfig() *tls.Config {
+	return l.tlsConfig
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/infodancer/pop3d/internal/config"
+	"github.com/infodancer/pop3d/internal/logging"
+)
+
+// Server coordinates multiple listeners and handles POP3 connections.
+type Server struct {
+	cfg       *config.Config
+	tlsConfig *tls.Config
+	logger    *slog.Logger
+	handler   ConnectionHandler
+
+	listeners []*Listener
+	mu        sync.Mutex
+}
+
+// New creates a new Server with the given configuration.
+func New(cfg *config.Config) (*Server, error) {
+	logger := logging.NewLogger(cfg.LogLevel)
+
+	s := &Server{
+		cfg:    cfg,
+		logger: logger,
+	}
+
+	// Load TLS configuration if certificates are specified
+	if cfg.TLS.CertFile != "" && cfg.TLS.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.TLS.CertFile, cfg.TLS.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading TLS certificate: %w", err)
+		}
+
+		s.tlsConfig = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   cfg.TLS.MinTLSVersion(),
+		}
+		logger.Info("TLS configured",
+			slog.String("cert", cfg.TLS.CertFile),
+			slog.String("min_version", cfg.TLS.MinVersion),
+		)
+	}
+
+	return s, nil
+}
+
+// SetHandler sets the connection handler for all listeners.
+// Must be called before Run.
+func (s *Server) SetHandler(handler ConnectionHandler) {
+	s.handler = handler
+}
+
+// Run starts all configured listeners and blocks until the context is cancelled.
+// All listeners run in their own goroutines.
+func (s *Server) Run(ctx context.Context) error {
+	s.mu.Lock()
+
+	if s.handler == nil {
+		s.handler = s.defaultHandler
+	}
+
+	// Create listeners
+	for _, lc := range s.cfg.Listeners {
+		// Determine if this listener needs TLS
+		var tlsCfg *tls.Config
+		if lc.Mode == config.ModePop3s {
+			if s.tlsConfig == nil {
+				s.mu.Unlock()
+				return fmt.Errorf("listener %s: TLS required for POP3S mode but not configured", lc.Address)
+			}
+			tlsCfg = s.tlsConfig
+		} else if s.tlsConfig != nil {
+			// Make TLS available for STLS on non-POP3S listeners
+			tlsCfg = s.tlsConfig
+		}
+
+		listener := NewListener(ListenerConfig{
+			Address:        lc.Address,
+			Mode:           lc.Mode,
+			TLSConfig:      tlsCfg,
+			IdleTimeout:    s.cfg.Timeouts.ConnectionTimeout(),
+			CommandTimeout: s.cfg.Timeouts.CommandTimeout(),
+			LogTransaction: s.cfg.LogLevel == "debug",
+			Logger:         s.logger,
+			Handler:        s.handler,
+		})
+		s.listeners = append(s.listeners, listener)
+	}
+
+	s.mu.Unlock()
+
+	s.logger.Info("starting server",
+		slog.String("hostname", s.cfg.Hostname),
+		slog.Int("listener_count", len(s.listeners)),
+	)
+
+	// Start all listeners in goroutines
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(s.listeners))
+
+	for _, l := range s.listeners {
+		wg.Add(1)
+		go func(listener *Listener) {
+			defer wg.Done()
+			if err := listener.Start(ctx); err != nil && err != context.Canceled {
+				errChan <- fmt.Errorf("listener %s: %w", listener.Address(), err)
+			}
+		}(l)
+	}
+
+	// Wait for context cancellation
+	<-ctx.Done()
+
+	s.logger.Info("server shutting down")
+
+	// Wait for all listeners to stop
+	wg.Wait()
+
+	// Check for any errors
+	close(errChan)
+	var firstErr error
+	for err := range errChan {
+		if firstErr == nil {
+			firstErr = err
+		}
+		s.logger.Error("listener error", slog.String("error", err.Error()))
+	}
+
+	s.logger.Info("server stopped")
+
+	if firstErr != nil {
+		return firstErr
+	}
+	return ctx.Err()
+}
+
+// Shutdown gracefully stops the server.
+// It closes all listeners and waits for connections to complete.
+func (s *Server) Shutdown() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, l := range s.listeners {
+		_ = l.Close()
+	}
+}
+
+// Logger returns the server's logger.
+func (s *Server) Logger() *slog.Logger {
+	return s.logger
+}
+
+// TLSConfig returns the server's TLS configuration, if any.
+func (s *Server) TLSConfig() *tls.Config {
+	return s.tlsConfig
+}
+
+// Config returns the server's configuration.
+func (s *Server) Config() *config.Config {
+	return s.cfg
+}
+
+// defaultHandler is a placeholder handler that logs connections.
+// This should be replaced with actual POP3 protocol handling.
+func (s *Server) defaultHandler(ctx context.Context, conn *Connection) {
+	logger := logging.FromContext(ctx)
+	logger.Info("connection handler not implemented - closing connection")
+}


### PR DESCRIPTION
## Summary

Implements POP3 authentication using msgstore's AuthenticationAgent interface with TLS-aware security controls that prevent advertising or accepting plaintext authentication over non-TLS connections.

This PR builds the complete server infrastructure (which didn't exist) and implements RFC-compliant authentication commands.

## Changes

### Server Infrastructure
- **Multi-listener TCP server** supporting ModePop3 (port 110, optional STARTTLS) and ModePop3s (port 995, implicit TLS)
- **Connection wrapper** with timeout management and TLS upgrade capability
- **Context-based logging** with connection correlation IDs for request tracing

### POP3 Protocol Implementation
- **State machine**: AUTHORIZATION → TRANSACTION → UPDATE (per RFC 1939)
- **TLS state tracking**: Dynamic capability advertisement based on security context
- **Command interface and registry** for extensibility
- **Protocol handler** with command loop, TLS upgrade handling, and error recovery

### Authentication Commands
- **CAPA**: Dynamic capability list that changes based on TLS state (RFC 2449)
- **STLS**: TLS upgrade for ModePop3 listeners (RFC 2595)
- **USER**: Username specification (requires TLS on ModePop3)
- **PASS**: Password authentication via AuthenticationAgent (requires TLS on ModePop3)
- **QUIT**: Session termination with proper state cleanup

### Security Features
✅ USER/PASS rejected without TLS on ModePop3 listeners
✅ CAPA never advertises USER before TLS on ModePop3
✅ Generic authentication errors to prevent user enumeration
✅ AuthSession.Clear() called on disconnect to zero private keys
✅ TLS enforcement configurable per listener mode

### Testing
- Comprehensive unit tests for all authentication commands (88-100% coverage)
- Session state machine tests covering all transitions
- Command parsing and response formatting tests
- **56.5% test coverage** for pop3 package overall
- **81.7% test coverage** for config package

## Implementation Details

### Key Files Added
- `internal/server/` - TCP server infrastructure (ported from smtpd pattern)
- `internal/logging/` - Context-based logging utilities
- `internal/pop3/session.go` - POP3 state machine with TLS tracking
- `internal/pop3/auth_commands.go` - USER, PASS, CAPA, STLS, QUIT implementations
- `internal/pop3/handler.go` - Protocol handler with command loop
- `cmd/pop3d/main.go` - Server initialization with AuthenticationAgent

### Security Model

**Core Principle**: Never advertise or accept plaintext authentication over non-TLS connections.

**CAPA Behavior**:
- **Before TLS** (ModePop3): Advertises STLS, TOP, UIDL, RESP-CODES (NO USER)
- **After TLS** (ModePop3 + STARTTLS or ModePop3s): Advertises USER, TOP, UIDL, RESP-CODES (NO STLS)

**Command Enforcement**:
- USER/PASS check `tlsState == TLSStateActive` before processing
- Return `-ERR TLS required for authentication` if attempted without TLS
- STLS only available on ModePop3 listeners before TLS upgrade

## Test Plan

### Unit Tests (Passing)
```bash
go test ./internal/pop3/... -cover
# ok  	github.com/infodancer/pop3d/internal/pop3	coverage: 56.5%
```

### Linter (Passing)
```bash
task lint
# 0 issues.
```

### Manual Testing Checklist
- [ ] ModePop3 listener rejects USER/PASS before STARTTLS
- [ ] CAPA before STARTTLS does NOT advertise USER
- [ ] STLS upgrades connection successfully
- [ ] CAPA after STARTTLS DOES advertise USER
- [ ] Valid credentials authenticate successfully
- [ ] ModePop3s listener accepts USER/PASS immediately (implicit TLS)

## References

- Issue: #10
- RFC 1939: POP3 protocol
- RFC 2595: STARTTLS for POP3
- RFC 2449: CAPA command
- msgstore AuthenticationAgent: https://github.com/infodancer/msgstore

🤖 Generated with [Claude Code](https://claude.com/claude-code)