### PR TITLE
Add plus-addressing folder routing for POP3 (pop3d#18)

### DIFF
--- a/internal/pop3/auth_commands.go
+++ b/internal/pop3/auth_commands.go
@@ -155,7 +155,7 @@ func (p *passCommand) Execute(ctx context.Context, sess *Session, conn Connectio
 		store = result.Domain.MessageStore
 	}
 	if store != nil {
-		if err := sess.InitializeMailbox(ctx, store); err != nil {
+		if err := sess.InitializeMailbox(ctx, store, result.Extension); err != nil {
 			conn.Logger().Error("failed to initialize mailbox",
 				"username", username,
 				"mailbox", result.Session.User.Mailbox,
@@ -270,7 +270,7 @@ func (a *authCommand) Execute(ctx context.Context, sess *Session, conn Connectio
 				store = result.Domain.MessageStore
 			}
 			if store != nil {
-				if err := sess.InitializeMailbox(ctx, store); err != nil {
+				if err := sess.InitializeMailbox(ctx, store, result.Extension); err != nil {
 					conn.Logger().Error("failed to initialize mailbox",
 						"mechanism", mechanism,
 						"username", username,

--- a/internal/pop3/folder_store.go
+++ b/internal/pop3/folder_store.go
@@ -1,0 +1,37 @@
+package pop3
+
+import (
+	"context"
+	"io"
+
+	"github.com/infodancer/msgstore"
+)
+
+// folderMessageStore adapts a msgstore.FolderStore to the msgstore.MessageStore
+// interface for a specific folder. This allows POP3 sessions for subaddressed
+// users (user+folder@domain) to present the folder as if it were their inbox,
+// with no changes needed to the command layer.
+type folderMessageStore struct {
+	fs     msgstore.FolderStore
+	folder string
+}
+
+func (a *folderMessageStore) List(ctx context.Context, mailbox string) ([]msgstore.MessageInfo, error) {
+	return a.fs.ListInFolder(ctx, mailbox, a.folder)
+}
+
+func (a *folderMessageStore) Retrieve(ctx context.Context, mailbox, uid string) (io.ReadCloser, error) {
+	return a.fs.RetrieveFromFolder(ctx, mailbox, a.folder, uid)
+}
+
+func (a *folderMessageStore) Delete(ctx context.Context, mailbox, uid string) error {
+	return a.fs.DeleteInFolder(ctx, mailbox, a.folder, uid)
+}
+
+func (a *folderMessageStore) Expunge(ctx context.Context, mailbox string) error {
+	return a.fs.ExpungeFolder(ctx, mailbox, a.folder)
+}
+
+func (a *folderMessageStore) Stat(ctx context.Context, mailbox string) (int, int64, error) {
+	return a.fs.StatFolder(ctx, mailbox, a.folder)
+}

--- a/internal/pop3/folder_store_test.go
+++ b/internal/pop3/folder_store_test.go
@@ -1,0 +1,172 @@
+package pop3
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/infodancer/auth"
+	"github.com/infodancer/msgstore"
+	"github.com/infodancer/pop3d/internal/config"
+)
+
+// mockFolderStore implements both msgstore.MessageStore and msgstore.FolderStore.
+// It tracks which folders exist and what messages each folder contains.
+type mockFolderStore struct {
+	// inbox messages
+	inbox []msgstore.MessageInfo
+	// per-folder messages
+	folders map[string][]msgstore.MessageInfo
+}
+
+func newMockFolderStore(folders map[string][]msgstore.MessageInfo) *mockFolderStore {
+	return &mockFolderStore{
+		inbox: []msgstore.MessageInfo{
+			{UID: "inbox1", Size: 100},
+		},
+		folders: folders,
+	}
+}
+
+// MessageStore interface
+func (m *mockFolderStore) List(_ context.Context, _ string) ([]msgstore.MessageInfo, error) {
+	return m.inbox, nil
+}
+
+func (m *mockFolderStore) Retrieve(_ context.Context, _, uid string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("Subject: " + uid + "\r\n\r\nbody\r\n")), nil
+}
+
+func (m *mockFolderStore) Delete(_ context.Context, _, _ string) error { return nil }
+
+func (m *mockFolderStore) Expunge(_ context.Context, _ string) error { return nil }
+
+func (m *mockFolderStore) Stat(_ context.Context, _ string) (int, int64, error) {
+	var total int64
+	for _, msg := range m.inbox {
+		total += msg.Size
+	}
+	return len(m.inbox), total, nil
+}
+
+// FolderStore interface
+func (m *mockFolderStore) ListFolders(_ context.Context, _ string) ([]string, error) {
+	names := make([]string, 0, len(m.folders))
+	for name := range m.folders {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func (m *mockFolderStore) CreateFolder(_ context.Context, _, _ string) error { return nil }
+
+func (m *mockFolderStore) DeleteFolder(_ context.Context, _, _ string) error { return nil }
+
+func (m *mockFolderStore) ListInFolder(_ context.Context, _, folder string) ([]msgstore.MessageInfo, error) {
+	msgs, ok := m.folders[folder]
+	if !ok {
+		return nil, nil
+	}
+	return msgs, nil
+}
+
+func (m *mockFolderStore) StatFolder(_ context.Context, _, folder string) (int, int64, error) {
+	msgs := m.folders[folder]
+	var total int64
+	for _, msg := range msgs {
+		total += msg.Size
+	}
+	return len(msgs), total, nil
+}
+
+func (m *mockFolderStore) RetrieveFromFolder(_ context.Context, _, folder, uid string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("Subject: " + folder + "/" + uid + "\r\n\r\nbody\r\n")), nil
+}
+
+func (m *mockFolderStore) DeleteInFolder(_ context.Context, _, _, _ string) error { return nil }
+
+func (m *mockFolderStore) ExpungeFolder(_ context.Context, _, _ string) error { return nil }
+
+func (m *mockFolderStore) DeliverToFolder(_ context.Context, _, _ string, _ io.Reader) error {
+	return nil
+}
+
+// helper: authenticated session ready for InitializeMailbox
+func newAuthenticatedSession() *Session {
+	sess := NewSession("test.example.com", config.ModePop3s, nil, true)
+	sess.SetAuthenticated(&auth.AuthSession{
+		User: &auth.User{
+			Username: "testuser",
+			Mailbox:  "/var/mail/testuser",
+		},
+	})
+	return sess
+}
+
+func TestInitializeMailbox_NoFolder(t *testing.T) {
+	store := newMockFolderStore(map[string][]msgstore.MessageInfo{
+		"work": {{UID: "w1", Size: 50}},
+	})
+	sess := newAuthenticatedSession()
+
+	if err := sess.InitializeMailbox(context.Background(), store, ""); err != nil {
+		t.Fatalf("InitializeMailbox: %v", err)
+	}
+
+	// No folder specified — should use inbox (1 message)
+	if got := sess.MessageCount(); got != 1 {
+		t.Errorf("MessageCount() = %d, want 1 (inbox)", got)
+	}
+}
+
+func TestInitializeMailbox_FolderExists(t *testing.T) {
+	folderMsgs := []msgstore.MessageInfo{
+		{UID: "w1", Size: 50},
+		{UID: "w2", Size: 75},
+	}
+	store := newMockFolderStore(map[string][]msgstore.MessageInfo{
+		"work": folderMsgs,
+	})
+	sess := newAuthenticatedSession()
+
+	if err := sess.InitializeMailbox(context.Background(), store, "work"); err != nil {
+		t.Fatalf("InitializeMailbox: %v", err)
+	}
+
+	// Folder exists — should see folder messages, not inbox
+	if got := sess.MessageCount(); got != 2 {
+		t.Errorf("MessageCount() = %d, want 2 (folder)", got)
+	}
+}
+
+func TestInitializeMailbox_FolderMissing(t *testing.T) {
+	store := newMockFolderStore(map[string][]msgstore.MessageInfo{
+		"work": {{UID: "w1", Size: 50}},
+	})
+	sess := newAuthenticatedSession()
+
+	// Request a folder that does not exist — should fall back to inbox
+	if err := sess.InitializeMailbox(context.Background(), store, "nosuchfolder"); err != nil {
+		t.Fatalf("InitializeMailbox: %v", err)
+	}
+
+	if got := sess.MessageCount(); got != 1 {
+		t.Errorf("MessageCount() = %d, want 1 (inbox fallback)", got)
+	}
+}
+
+func TestInitializeMailbox_StoreNotFolderStore(t *testing.T) {
+	// Use a plain MessageStore (no FolderStore support)
+	store := newMockMessageStore()
+	sess := newAuthenticatedSession()
+
+	// Extension requested but store doesn't implement FolderStore — inbox fallback
+	if err := sess.InitializeMailbox(context.Background(), store, "work"); err != nil {
+		t.Fatalf("InitializeMailbox: %v", err)
+	}
+
+	if got := sess.MessageCount(); got != 3 {
+		t.Errorf("MessageCount() = %d, want 3 (inbox, no folder support)", got)
+	}
+}

--- a/internal/pop3/transaction_commands_test.go
+++ b/internal/pop3/transaction_commands_test.go
@@ -86,7 +86,7 @@ func newTransactionSession(store msgstore.MessageStore) *Session {
 		},
 	})
 	if store != nil {
-		_ = sess.InitializeMailbox(context.Background(), store)
+		_ = sess.InitializeMailbox(context.Background(), store, "")
 	}
 	return sess
 }


### PR DESCRIPTION
## Summary

- Implements POP3 subaddress folder routing: `user+folder@domain` now presents the named Maildir++ folder as the inbox during a POP3 session
- Falls back silently to the normal inbox if the folder doesn't exist or the store doesn't implement `FolderStore` — consistent with delivery-side behavior
- Both USER/PASS and SASL/AUTH paths pass `result.Extension` to `InitializeMailbox`

## Changes

- `folder_store.go` — new `folderMessageStore` adapter wrapping `msgstore.FolderStore` for a specific folder, implementing `MessageStore` so the command layer needs no changes
- `session.go` — `InitializeMailbox` accepts a `folder string` parameter; type-asserts to `FolderStore`, checks `ListFolders`, wires up adapter if found
- `auth_commands.go` — both `passCommand` and `authCommand` now pass `result.Extension`
- `transaction_commands_test.go` — updated helper call site for new signature
- `folder_store_test.go` — four new tests covering: no folder, folder exists, folder missing (fallback), store without FolderStore support

## Test plan

- [x] `TestInitializeMailbox_NoFolder` — empty extension uses inbox
- [x] `TestInitializeMailbox_FolderExists` — named folder routes to folder messages
- [x] `TestInitializeMailbox_FolderMissing` — absent folder falls back to inbox
- [x] `TestInitializeMailbox_StoreNotFolderStore` — plain store ignores extension
- [x] Full suite passes: `go test ./...`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)