### PR TITLE
Use persistent uint32 UIDs from msgstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.26.1
 require (
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/infodancer/auth v0.1.14
-	github.com/infodancer/mail-session v0.1.2
-	github.com/infodancer/msgstore v0.2.4
-	github.com/infodancer/session-manager v0.1.0
+	github.com/infodancer/mail-session v0.1.3-0.20260313080315-2774e158a243
+	github.com/infodancer/msgstore v0.2.5-0.20260313075010-ceed9cfc0b22
+	github.com/infodancer/session-manager v0.1.2-0.20260313080955-e5678627d2f2
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 	golang.org/x/crypto v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -25,10 +25,16 @@ github.com/infodancer/auth v0.1.14 h1:xm/QQF7EIRpg9fOlXha84j4jgPLPU/IOo/67wUFMpK
 github.com/infodancer/auth v0.1.14/go.mod h1:Vd8guaF2+FD/BPpBN4Tr+dAMXm++OZ2h38cXpl8OZcA=
 github.com/infodancer/mail-session v0.1.2 h1:cqOMVUOFXPTFITKYQoL/y5yTlguEoQ8D+W0VMUODh9A=
 github.com/infodancer/mail-session v0.1.2/go.mod h1:W+Io4Xdc+DmfkyrHv2/w47QSXFtUKM0rAiKbiO1VKZs=
+github.com/infodancer/mail-session v0.1.3-0.20260313080315-2774e158a243 h1:7YA0iOAIHKvnOS9aZNiIyGKVpg5EV7tibgQwXvELA/Q=
+github.com/infodancer/mail-session v0.1.3-0.20260313080315-2774e158a243/go.mod h1:NIKAsXdhoInHtVt1PB8NN4bBYEH9moz7Mn9UGUoZKNg=
 github.com/infodancer/msgstore v0.2.4 h1:Rs/57J2iYJYbfu9+WprrjkryBohB2y/pjlEHECVfdlM=
 github.com/infodancer/msgstore v0.2.4/go.mod h1:rW0pT8rguFR8OPbFoQyA7gk1X39at2q8YNmFFNnrx24=
+github.com/infodancer/msgstore v0.2.5-0.20260313075010-ceed9cfc0b22 h1:KoxGxSdncW3nulz+wF2iZTrdv/z6FYX2GhCHIZtiIE4=
+github.com/infodancer/msgstore v0.2.5-0.20260313075010-ceed9cfc0b22/go.mod h1:rW0pT8rguFR8OPbFoQyA7gk1X39at2q8YNmFFNnrx24=
 github.com/infodancer/session-manager v0.1.0 h1:Ls3fp9E1rKQRzi9jIy4w3c6v7JM6kzWywMsppZ6927E=
 github.com/infodancer/session-manager v0.1.0/go.mod h1:CUK5HGwJvtRVlgTpsb2wPOIIsxcw3jjfzKDWQRQU/HQ=
+github.com/infodancer/session-manager v0.1.2-0.20260313080955-e5678627d2f2 h1:qbzZ41fnBHrtL2++kas2HqWPcEKM8WIYZ4zVwsvcBHI=
+github.com/infodancer/session-manager v0.1.2-0.20260313080955-e5678627d2f2/go.mod h1:9IgrLg0uS1kpmT4tJBwj/yqEU23w3nj/8i0xYjIS4TQ=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/pop3/folder_store.go
+++ b/internal/pop3/folder_store.go
@@ -20,11 +20,11 @@ func (a *folderMessageStore) List(ctx context.Context, mailbox string) ([]msgsto
 	return a.fs.ListInFolder(ctx, mailbox, a.folder)
 }
 
-func (a *folderMessageStore) Retrieve(ctx context.Context, mailbox, uid string) (io.ReadCloser, error) {
+func (a *folderMessageStore) Retrieve(ctx context.Context, mailbox string, uid uint32) (io.ReadCloser, error) {
 	return a.fs.RetrieveFromFolder(ctx, mailbox, a.folder, uid)
 }
 
-func (a *folderMessageStore) Delete(ctx context.Context, mailbox, uid string) error {
+func (a *folderMessageStore) Delete(ctx context.Context, mailbox string, uid uint32) error {
 	return a.fs.DeleteInFolder(ctx, mailbox, a.folder, uid)
 }
 
@@ -35,4 +35,3 @@ func (a *folderMessageStore) Expunge(ctx context.Context, mailbox string) error 
 func (a *folderMessageStore) Stat(ctx context.Context, mailbox string) (int, int64, error) {
 	return a.fs.StatFolder(ctx, mailbox, a.folder)
 }
-

--- a/internal/pop3/folder_store_test.go
+++ b/internal/pop3/folder_store_test.go
@@ -2,6 +2,7 @@ package pop3
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -24,7 +25,7 @@ type mockFolderStore struct {
 func newMockFolderStore(folders map[string][]msgstore.MessageInfo) *mockFolderStore {
 	return &mockFolderStore{
 		inbox: []msgstore.MessageInfo{
-			{UID: "inbox1", Size: 100},
+			{UID: 1, Size: 100},
 		},
 		folders: folders,
 	}
@@ -35,11 +36,11 @@ func (m *mockFolderStore) List(_ context.Context, _ string) ([]msgstore.MessageI
 	return m.inbox, nil
 }
 
-func (m *mockFolderStore) Retrieve(_ context.Context, _, uid string) (io.ReadCloser, error) {
-	return io.NopCloser(strings.NewReader("Subject: " + uid + "\r\n\r\nbody\r\n")), nil
+func (m *mockFolderStore) Retrieve(_ context.Context, _ string, uid uint32) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(fmt.Sprintf("Subject: %d\r\n\r\nbody\r\n", uid))), nil
 }
 
-func (m *mockFolderStore) Delete(_ context.Context, _, _ string) error { return nil }
+func (m *mockFolderStore) Delete(_ context.Context, _ string, _ uint32) error { return nil }
 
 func (m *mockFolderStore) Expunge(_ context.Context, _ string) error { return nil }
 
@@ -50,7 +51,6 @@ func (m *mockFolderStore) Stat(_ context.Context, _ string) (int, int64, error) 
 	}
 	return len(m.inbox), total, nil
 }
-
 
 // FolderStore interface
 func (m *mockFolderStore) ListFolders(_ context.Context, _ string) ([]string, error) {
@@ -82,11 +82,11 @@ func (m *mockFolderStore) StatFolder(_ context.Context, _, folder string) (int, 
 	return len(msgs), total, nil
 }
 
-func (m *mockFolderStore) RetrieveFromFolder(_ context.Context, _, folder, uid string) (io.ReadCloser, error) {
-	return io.NopCloser(strings.NewReader("Subject: " + folder + "/" + uid + "\r\n\r\nbody\r\n")), nil
+func (m *mockFolderStore) RetrieveFromFolder(_ context.Context, _, folder string, uid uint32) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(fmt.Sprintf("Subject: %s/%d\r\n\r\nbody\r\n", folder, uid))), nil
 }
 
-func (m *mockFolderStore) DeleteInFolder(_ context.Context, _, _, _ string) error { return nil }
+func (m *mockFolderStore) DeleteInFolder(_ context.Context, _, _ string, _ uint32) error { return nil }
 
 func (m *mockFolderStore) ExpungeFolder(_ context.Context, _, _ string) error { return nil }
 
@@ -96,20 +96,24 @@ func (m *mockFolderStore) DeliverToFolder(_ context.Context, _, _ string, _ io.R
 
 func (m *mockFolderStore) RenameFolder(_ context.Context, _, _, _ string) error { return nil }
 
-func (m *mockFolderStore) AppendToFolder(_ context.Context, _, _ string, _ io.Reader, _ []string, _ time.Time) (string, error) {
-	return "", nil
+func (m *mockFolderStore) AppendToFolder(_ context.Context, _, _ string, _ io.Reader, _ []string, _ time.Time) (uint32, error) {
+	return 0, nil
 }
 
-func (m *mockFolderStore) SetFlagsInFolder(_ context.Context, _, _, _ string, _ []string) error {
+func (m *mockFolderStore) SetFlagsInFolder(_ context.Context, _, _ string, _ uint32, _ []string) error {
 	return nil
 }
 
-func (m *mockFolderStore) CopyMessage(_ context.Context, _, _, _, _ string) (string, error) {
-	return "", nil
+func (m *mockFolderStore) CopyMessage(_ context.Context, _, _ string, _ uint32, _ string) (uint32, error) {
+	return 0, nil
 }
 
 func (m *mockFolderStore) UIDValidity(_ context.Context, _, _ string) (uint32, error) {
 	return 1, nil
+}
+
+func (m *mockFolderStore) UIDNext(_ context.Context, _, _ string) (uint32, error) {
+	return 2, nil
 }
 
 // helper: authenticated session ready for InitializeMailbox
@@ -126,7 +130,7 @@ func newAuthenticatedSession() *Session {
 
 func TestInitializeMailbox_NoFolder(t *testing.T) {
 	store := newMockFolderStore(map[string][]msgstore.MessageInfo{
-		"work": {{UID: "w1", Size: 50}},
+		"work": {{UID: 10, Size: 50}},
 	})
 	sess := newAuthenticatedSession()
 
@@ -142,8 +146,8 @@ func TestInitializeMailbox_NoFolder(t *testing.T) {
 
 func TestInitializeMailbox_FolderExists(t *testing.T) {
 	folderMsgs := []msgstore.MessageInfo{
-		{UID: "w1", Size: 50},
-		{UID: "w2", Size: 75},
+		{UID: 10, Size: 50},
+		{UID: 11, Size: 75},
 	}
 	store := newMockFolderStore(map[string][]msgstore.MessageInfo{
 		"work": folderMsgs,
@@ -162,7 +166,7 @@ func TestInitializeMailbox_FolderExists(t *testing.T) {
 
 func TestInitializeMailbox_FolderMissing(t *testing.T) {
 	store := newMockFolderStore(map[string][]msgstore.MessageInfo{
-		"work": {{UID: "w1", Size: 50}},
+		"work": {{UID: 10, Size: 50}},
 	})
 	sess := newAuthenticatedSession()
 

--- a/internal/pop3/grpcsession.go
+++ b/internal/pop3/grpcsession.go
@@ -97,14 +97,14 @@ func (g *grpcSessionStore) List(ctx context.Context, mailbox string) ([]msgstore
 	return g.client.List(ctx, mailbox)
 }
 
-func (g *grpcSessionStore) Retrieve(ctx context.Context, mailbox, uid string) (io.ReadCloser, error) {
+func (g *grpcSessionStore) Retrieve(ctx context.Context, mailbox string, uid uint32) (io.ReadCloser, error) {
 	if err := g.ensureReady(mailbox); err != nil {
 		return nil, err
 	}
 	return g.client.Retrieve(ctx, mailbox, uid)
 }
 
-func (g *grpcSessionStore) Delete(ctx context.Context, mailbox, uid string) error {
+func (g *grpcSessionStore) Delete(ctx context.Context, mailbox string, uid uint32) error {
 	if err := g.ensureReady(mailbox); err != nil {
 		return err
 	}

--- a/internal/pop3/session.go
+++ b/internal/pop3/session.go
@@ -366,11 +366,11 @@ func (s *Session) ResetDeletions() {
 }
 
 // GetDeletedUIDs returns the UIDs of messages marked for deletion.
-func (s *Session) GetDeletedUIDs() []string {
+func (s *Session) GetDeletedUIDs() []uint32 {
 	if s.messageList == nil {
 		return nil
 	}
-	var uids []string
+	var uids []uint32
 	for msgNum := range s.deletedSet {
 		if msgNum >= 1 && msgNum <= len(s.messageList) {
 			uids = append(uids, s.messageList[msgNum-1].UID)

--- a/internal/pop3/smclient.go
+++ b/internal/pop3/smclient.go
@@ -116,7 +116,7 @@ func (c *SessionManagerClient) StatMailbox(ctx context.Context, token, folder st
 
 // FetchMessage retrieves a message by UID. The returned ReadCloser assembles
 // the server-streamed chunks into a contiguous byte stream.
-func (c *SessionManagerClient) FetchMessage(ctx context.Context, token, folder, uid string) (io.ReadCloser, error) {
+func (c *SessionManagerClient) FetchMessage(ctx context.Context, token, folder string, uid uint32) (io.ReadCloser, error) {
 	stream, err := c.mailbox.Fetch(tokenCtx(ctx, token), &pb.FetchRequest{
 		Folder: folder,
 		Uid:    uid,
@@ -140,7 +140,7 @@ func (c *SessionManagerClient) FetchMessage(ctx context.Context, token, folder, 
 }
 
 // DeleteMessage marks a message for POP3-style deletion.
-func (c *SessionManagerClient) DeleteMessage(ctx context.Context, token, uid string) error {
+func (c *SessionManagerClient) DeleteMessage(ctx context.Context, token string, uid uint32) error {
 	_, err := c.mailbox.Delete(tokenCtx(ctx, token), &pb.DeleteRequest{Uid: uid})
 	return err
 }

--- a/internal/pop3/smclient_test.go
+++ b/internal/pop3/smclient_test.go
@@ -57,8 +57,8 @@ func (m *mockMailboxService) List(ctx context.Context, req *pb.ListRequest) (*pb
 	}
 	return &pb.ListResponse{
 		Messages: []*pb.MessageInfo{
-			{Uid: "msg1", Size: 1024},
-			{Uid: "msg2", Size: 2048},
+			{Uid: 1, Size: 1024},
+			{Uid: 2, Size: 2048},
 		},
 	}, nil
 }
@@ -193,8 +193,8 @@ func TestSessionManagerClient_ListMessages(t *testing.T) {
 	if len(msgs) != 2 {
 		t.Fatalf("got %d messages, want 2", len(msgs))
 	}
-	if msgs[0].Uid != "msg1" || msgs[0].Size != 1024 {
-		t.Errorf("msg[0] = %+v, want uid=msg1 size=1024", msgs[0])
+	if msgs[0].Uid != 1 || msgs[0].Size != 1024 {
+		t.Errorf("msg[0] = %+v, want uid=1 size=1024", msgs[0])
 	}
 }
 
@@ -270,7 +270,7 @@ func TestSessionManagerClient_FetchMessage(t *testing.T) {
 	}
 	defer func() { _ = client.Close() }()
 
-	rc, err := client.FetchMessage(context.Background(), "tok", "", "msg1")
+	rc, err := client.FetchMessage(context.Background(), "tok", "", 1)
 	if err != nil {
 		t.Fatalf("FetchMessage: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestSessionManagerClient_FetchMessage(t *testing.T) {
 }
 
 func TestSessionManagerClient_DeleteAndExpunge(t *testing.T) {
-	var deletedUID string
+	var deletedUID uint32
 	var expungedFolder string
 	mailboxSvc := &mockMailboxService{
 		deleteFunc: func(ctx context.Context, req *pb.DeleteRequest) (*pb.DeleteResponse, error) {
@@ -311,11 +311,11 @@ func TestSessionManagerClient_DeleteAndExpunge(t *testing.T) {
 	defer func() { _ = client.Close() }()
 
 	ctx := context.Background()
-	if err := client.DeleteMessage(ctx, "tok", "msg1"); err != nil {
+	if err := client.DeleteMessage(ctx, "tok", 1); err != nil {
 		t.Fatalf("DeleteMessage: %v", err)
 	}
-	if deletedUID != "msg1" {
-		t.Errorf("deleted UID = %q, want %q", deletedUID, "msg1")
+	if deletedUID != 1 {
+		t.Errorf("deleted UID = %d, want 1", deletedUID)
 	}
 
 	if err := client.ExpungeMailbox(ctx, "tok", "INBOX"); err != nil {
@@ -430,7 +430,7 @@ func TestSessionManagerStore_ListAndStat(t *testing.T) {
 	if len(msgs) != 2 {
 		t.Fatalf("got %d messages, want 2", len(msgs))
 	}
-	if msgs[0].UID != "msg1" || msgs[0].Size != 1024 {
+	if msgs[0].UID != 1 || msgs[0].Size != 1024 {
 		t.Errorf("msg[0] = %+v", msgs[0])
 	}
 

--- a/internal/pop3/smstore.go
+++ b/internal/pop3/smstore.go
@@ -49,11 +49,11 @@ func (s *sessionManagerStore) Stat(ctx context.Context, mailbox string) (int, in
 	return int(count), totalBytes, nil
 }
 
-func (s *sessionManagerStore) Retrieve(ctx context.Context, mailbox, uid string) (io.ReadCloser, error) {
+func (s *sessionManagerStore) Retrieve(ctx context.Context, mailbox string, uid uint32) (io.ReadCloser, error) {
 	return s.client.FetchMessage(ctx, s.token, "", uid)
 }
 
-func (s *sessionManagerStore) Delete(ctx context.Context, mailbox, uid string) error {
+func (s *sessionManagerStore) Delete(ctx context.Context, mailbox string, uid uint32) error {
 	return s.client.DeleteMessage(ctx, s.token, uid)
 }
 

--- a/internal/pop3/transaction_commands.go
+++ b/internal/pop3/transaction_commands.go
@@ -254,7 +254,7 @@ func (u *uidlCommand) Execute(ctx context.Context, sess *Session, conn Connectio
 		messages := sess.AllMessages()
 		lines := make([]string, len(messages))
 		for i, m := range messages {
-			lines[i] = fmt.Sprintf("%d %s", m.MsgNum, m.Info.UID)
+			lines[i] = fmt.Sprintf("%d %d", m.MsgNum, m.Info.UID)
 		}
 		return Response{
 			OK:      true,
@@ -281,7 +281,7 @@ func (u *uidlCommand) Execute(ctx context.Context, sess *Session, conn Connectio
 		return Response{OK: false, Message: "Failed to retrieve message"}, nil
 	}
 
-	return Response{OK: true, Message: fmt.Sprintf("%d %s", msgNum, msg.UID)}, nil
+	return Response{OK: true, Message: fmt.Sprintf("%d %d", msgNum, msg.UID)}, nil
 }
 
 // topCommand implements the TOP command (RFC 2449).

--- a/internal/pop3/transaction_commands_test.go
+++ b/internal/pop3/transaction_commands_test.go
@@ -13,28 +13,28 @@ import (
 
 // mockMessageStore is a test double for MessageStore.
 type mockMessageStore struct {
-	messages   []msgstore.MessageInfo
-	content    map[string]string // UID -> content
-	deleted    map[string]bool
-	listErr    error
+	messages    []msgstore.MessageInfo
+	content     map[uint32]string // UID -> content
+	deleted     map[uint32]bool
+	listErr     error
 	retrieveErr error
-	deleteErr  error
-	expungeErr error
+	deleteErr   error
+	expungeErr  error
 }
 
 func newMockMessageStore() *mockMessageStore {
 	return &mockMessageStore{
 		messages: []msgstore.MessageInfo{
-			{UID: "msg1", Size: 100},
-			{UID: "msg2", Size: 200},
-			{UID: "msg3", Size: 300},
+			{UID: 1, Size: 100},
+			{UID: 2, Size: 200},
+			{UID: 3, Size: 300},
 		},
-		content: map[string]string{
-			"msg1": "Subject: Test 1\r\n\r\nBody line 1\r\nBody line 2\r\n",
-			"msg2": "Subject: Test 2\r\n\r\nBody of message 2\r\n",
-			"msg3": "Subject: Test 3\r\nFrom: test@example.com\r\n\r\nLine 1\r\nLine 2\r\nLine 3\r\n",
+		content: map[uint32]string{
+			1: "Subject: Test 1\r\n\r\nBody line 1\r\nBody line 2\r\n",
+			2: "Subject: Test 2\r\n\r\nBody of message 2\r\n",
+			3: "Subject: Test 3\r\nFrom: test@example.com\r\n\r\nLine 1\r\nLine 2\r\nLine 3\r\n",
 		},
-		deleted: make(map[string]bool),
+		deleted: make(map[uint32]bool),
 	}
 }
 
@@ -45,7 +45,7 @@ func (m *mockMessageStore) List(ctx context.Context, mailbox string) ([]msgstore
 	return m.messages, nil
 }
 
-func (m *mockMessageStore) Retrieve(ctx context.Context, mailbox string, uid string) (io.ReadCloser, error) {
+func (m *mockMessageStore) Retrieve(ctx context.Context, mailbox string, uid uint32) (io.ReadCloser, error) {
 	if m.retrieveErr != nil {
 		return nil, m.retrieveErr
 	}
@@ -56,7 +56,7 @@ func (m *mockMessageStore) Retrieve(ctx context.Context, mailbox string, uid str
 	return io.NopCloser(strings.NewReader(content)), nil
 }
 
-func (m *mockMessageStore) Delete(ctx context.Context, mailbox string, uid string) error {
+func (m *mockMessageStore) Delete(ctx context.Context, mailbox string, uid uint32) error {
 	if m.deleteErr != nil {
 		return m.deleteErr
 	}
@@ -75,7 +75,6 @@ func (m *mockMessageStore) Stat(ctx context.Context, mailbox string) (int, int64
 	}
 	return len(m.messages), total, nil
 }
-
 
 // Helper to create a session in TRANSACTION state with messages loaded
 func newTransactionSession(store msgstore.MessageStore) *Session {
@@ -145,12 +144,12 @@ func TestStatCommand(t *testing.T) {
 
 func TestListCommand(t *testing.T) {
 	tests := []struct {
-		name         string
-		sess         *Session
-		args         []string
-		wantOK       bool
-		wantMessage  string
-		wantLines    int
+		name        string
+		sess        *Session
+		args        []string
+		wantOK      bool
+		wantMessage string
+		wantLines   int
 	}{
 		{
 			name:        "LIST in AUTHORIZATION state fails",
@@ -160,12 +159,12 @@ func TestListCommand(t *testing.T) {
 			wantMessage: "Command not valid in this state",
 		},
 		{
-			name:         "LIST all messages succeeds",
-			sess:         newTransactionSession(newMockMessageStore()),
-			args:         []string{},
-			wantOK:       true,
-			wantMessage:  "3 messages (600 octets)",
-			wantLines:    3,
+			name:        "LIST all messages succeeds",
+			sess:        newTransactionSession(newMockMessageStore()),
+			args:        []string{},
+			wantOK:      true,
+			wantMessage: "3 messages (600 octets)",
+			wantLines:   3,
 		},
 		{
 			name:        "LIST specific message succeeds",
@@ -497,12 +496,12 @@ func TestNoopCommand(t *testing.T) {
 
 func TestUidlCommand(t *testing.T) {
 	tests := []struct {
-		name         string
-		sess         *Session
-		args         []string
-		wantOK       bool
-		wantMessage  string
-		wantLines    int
+		name        string
+		sess        *Session
+		args        []string
+		wantOK      bool
+		wantMessage string
+		wantLines   int
 	}{
 		{
 			name:        "UIDL in AUTHORIZATION state fails",
@@ -512,19 +511,19 @@ func TestUidlCommand(t *testing.T) {
 			wantMessage: "Command not valid in this state",
 		},
 		{
-			name:         "UIDL all messages succeeds",
-			sess:         newTransactionSession(newMockMessageStore()),
-			args:         []string{},
-			wantOK:       true,
-			wantMessage:  "",
-			wantLines:    3,
+			name:        "UIDL all messages succeeds",
+			sess:        newTransactionSession(newMockMessageStore()),
+			args:        []string{},
+			wantOK:      true,
+			wantMessage: "",
+			wantLines:   3,
 		},
 		{
 			name:        "UIDL specific message succeeds",
 			sess:        newTransactionSession(newMockMessageStore()),
 			args:        []string{"1"},
 			wantOK:      true,
-			wantMessage: "1 msg1",
+			wantMessage: "1 1",
 		},
 		{
 			name:        "UIDL invalid message fails",


### PR DESCRIPTION
## Summary
- Update all uid parameters from `string` to `uint32` across the POP3 stack to match the new msgstore/mail-session/session-manager interfaces
- UIDL command now formats UIDs as decimal integers (`%d`) instead of strings
- `GetDeletedUIDs()` returns `[]uint32` for proper typed deletion in the QUIT handler
- All test mocks and assertions updated for uint32 UIDs

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass (including round-trip integration tests)
- [x] `golangci-lint run ./...` — 0 issues

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)